### PR TITLE
Add live YouTube stats to homepage

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,22 @@
 import { GitHub, LinkedIn, Twitter, YouTube } from "@/components/icons"
 import { CourseShelfBanner } from "@/components/courseshelf-banner"
+import { getChannelStats } from "@/data-access/youtube"
 
-export default function Home() {
+function formatNumber(num: number): string {
+  if (num >= 1_000_000) {
+    const formatted = (num / 1_000_000).toFixed(1)
+    return `${formatted.replace(/\.0$/, "")}M`
+  }
+  if (num >= 1_000) {
+    const formatted = (num / 1_000).toFixed(1)
+    return `${formatted.replace(/\.0$/, "")}K`
+  }
+  return num.toString()
+}
+
+export default async function Home() {
+  const { subscriberCount, viewCount } = await getChannelStats()
+
   return (
     <main className="text-left w-auto md:w-[560px] mx-auto my-28 md:my-44 flex flex-col gap-5">
       <h1 className="font-serif text-4xl md:text-5xl italic tracking-tight">
@@ -68,6 +83,29 @@ export default function Home() {
         >
           <GitHub width={24} height={24} />
         </a>
+      </section>
+
+      <section
+        aria-label="YouTube Stats"
+        className="flex items-center gap-8 md:gap-12 py-5 md:py-6 px-1"
+      >
+        <div className="flex flex-col gap-1">
+          <span className="text-2xl md:text-3xl font-bold tracking-tight">
+            {formatNumber(subscriberCount)}+
+          </span>
+          <span className="text-[10px] md:text-xs uppercase tracking-[0.2em] opacity-40">
+            Subscribers
+          </span>
+        </div>
+        <div className="w-px h-8 bg-current opacity-10" />
+        <div className="flex flex-col gap-1">
+          <span className="text-2xl md:text-3xl font-bold tracking-tight">
+            {formatNumber(viewCount)}+
+          </span>
+          <span className="text-[10px] md:text-xs uppercase tracking-[0.2em] opacity-40">
+            Views
+          </span>
+        </div>
       </section>
 
       <CourseShelfBanner />

--- a/src/data-access/youtube.ts
+++ b/src/data-access/youtube.ts
@@ -1,14 +1,25 @@
-import type { Playlists } from "@/lib/types"
+import type { ChannelStats, Playlists } from "@/lib/types"
 
 const API_KEY = process.env.YOUTUBE_API_KEY
 const CHANNEL_ID = process.env.YOUTUBE_CHANNEL_ID
 const BASE_URL = "https://www.googleapis.com/youtube/v3"
 const PLAYLISTS_URL = `${BASE_URL}/playlists?part=snippet,contentDetails&maxResults=50&key=${API_KEY}&channelId=${CHANNEL_ID}`
+const CHANNEL_URL = `${BASE_URL}/channels?part=statistics&id=${CHANNEL_ID}&key=${API_KEY}`
 
 const getPlaylists = async () => {
   const response = await fetch(PLAYLISTS_URL)
   const data: Playlists = await response.json()
   return data.items
+}
+
+export const getChannelStats = async () => {
+  const response = await fetch(CHANNEL_URL, { next: { revalidate: 86400 } })
+  const data: ChannelStats = await response.json()
+  const stats = data.items[0].statistics
+  return {
+    subscriberCount: Number(stats.subscriberCount),
+    viewCount: Number(stats.viewCount)
+  }
 }
 
 export const getCourses = async () => {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -10,6 +10,16 @@ export type Article = {
   tag_list: string[]
 }
 
+export type ChannelStats = {
+  items: {
+    statistics: {
+      viewCount: string
+      subscriberCount: string
+      videoCount: string
+    }
+  }[]
+}
+
 export type Playlists = {
   items: Video[]
 }


### PR DESCRIPTION
## Summary
- Display live YouTube subscriber count and total views on the homepage
- Fetch channel statistics via YouTube Data API v3 with 24-hour ISR revalidation
- Format large numbers with K/M suffixes (e.g., 15.6K+, 852.1K+)

## Changes
- **src/data-access/youtube.ts** — Added `getChannelStats()` using the YouTube Channels API
- **src/lib/types.ts** — Added `ChannelStats` type for the API response
- **src/app/page.tsx** — Made homepage async, added stats section between social icons and CourseShelf banner with `formatNumber` helper

## Test plan
- [ ] Verify stats display correctly on homepage with valid YouTube API key
- [ ] Check number formatting for various magnitudes (K, M)
- [ ] Confirm 24h revalidation works (stats refresh daily)
- [ ] Test responsive layout on mobile and desktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)