### PR TITLE
feat(newsletter): add Loops email signup form

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,6 @@
 YOUTUBE_API_KEY=
 YOUTUBE_CHANNEL_ID=
 DEV_TO_API_KEY=
+LOOPS_API_KEY=
+# Optional: add newsletter signups to a specific Loops mailing list.
+LOOPS_NEWSLETTER_LIST_ID=

--- a/README.md
+++ b/README.md
@@ -20,8 +20,12 @@ Copy `.env.example` to `.env` and fill in:
 - `YOUTUBE_API_KEY` — YouTube Data API key
 - `YOUTUBE_CHANNEL_ID` — channel ID for fetching videos and playlists
 - `DEV_TO_API_KEY` — Dev.to API key for articles
+- `LOOPS_API_KEY` — [Loops](https://loops.so) API key, powers the newsletter signup form
+- `LOOPS_NEWSLETTER_LIST_ID` — _(optional)_ Loops mailing list ID to add signups to; omit to use the default audience
 
-All three are required. The data-access layer throws on a failed API response (so a broken or empty page is never cached), so the build will error if a key is missing or invalid.
+The first three are required. The data-access layer throws on a failed API response (so a broken or empty page is never cached), so the build will error if a key is missing or invalid.
+
+`LOOPS_API_KEY` is only used at runtime by the newsletter signup (a Server Action), so the build succeeds without it — but the form will return an error until it's set. Generate a key in Loops under **Settings → API**.
 
 ## Scripts
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@opentelemetry/sdk-node": "^0.219.0",
+        "loops": "^7.0.0",
         "next": "^16.2.4",
         "react": "^19.2.5",
         "react-dom": "^19.2.5"
@@ -3193,6 +3194,15 @@
       "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
       "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
       "license": "Apache-2.0"
+    },
+    "node_modules/loops": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/loops/-/loops-7.0.0.tgz",
+      "integrity": "sha512-TNbnJndtZwE7Esmc6+xKy3xWZOqzq8xQ5IqvZ+CBS9MOjqcx8qgyfsWoW4F7oNZGkX7uS1+RDxvUAswwD2hR5Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/magic-string": {
       "version": "0.30.21",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@opentelemetry/sdk-node": "^0.219.0",
+    "loops": "^7.0.0",
     "next": "^16.2.4",
     "react": "^19.2.5",
     "react-dom": "^19.2.5"

--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -8,11 +8,6 @@ export type NewsletterState = {
   message: string
 }
 
-export const initialNewsletterState: NewsletterState = {
-  status: "idle",
-  message: ""
-}
-
 export async function subscribeToNewsletterAction(
   _prevState: NewsletterState,
   formData: FormData

--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -1,0 +1,49 @@
+"use server"
+
+import { subscribeToNewsletter } from "@/data-access/loops"
+import { isValidEmail } from "@/lib/utils"
+
+export type NewsletterState = {
+  status: "idle" | "success" | "error"
+  message: string
+}
+
+export const initialNewsletterState: NewsletterState = {
+  status: "idle",
+  message: ""
+}
+
+export async function subscribeToNewsletterAction(
+  _prevState: NewsletterState,
+  formData: FormData
+): Promise<NewsletterState> {
+  const email = String(formData.get("email") ?? "")
+
+  if (!isValidEmail(email)) {
+    return {
+      status: "error",
+      message: "Please enter a valid email address."
+    }
+  }
+
+  const result = await subscribeToNewsletter(email.trim())
+
+  if (result.ok) {
+    return {
+      status: "success",
+      message: "You're on the list. Watch your inbox for updates."
+    }
+  }
+
+  if (result.reason === "rate_limited") {
+    return {
+      status: "error",
+      message: "Too many requests right now. Please try again in a moment."
+    }
+  }
+
+  return {
+    status: "error",
+    message: "Something went wrong. Please try again later."
+  }
+}

--- a/src/app/courses/page.tsx
+++ b/src/app/courses/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next"
 
+import { NewsletterSignup } from "@/components/newsletter-signup"
 import { Video } from "@/components/video"
 import { getCourses } from "@/data-access/youtube"
 
@@ -64,6 +65,13 @@ export default async function Courses() {
           <Video video={playlist} key={playlist.id} locale="pt" />
         ))}
       </div>
+
+      <section aria-label="Course updates" className="mt-10 md:mt-14">
+        <NewsletterSignup
+          title="Be first to know about new courses"
+          description="I'm building premium courses. Drop your email to get early access, launch discounts, and updates on new free lessons."
+        />
+      </section>
     </main>
   )
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,7 @@
 import { GitHub, LinkedIn, Twitter, YouTube } from "@/components/icons"
 import { ContentCard } from "@/components/content-card"
 import { MembershipCTA } from "@/components/membership-cta"
+import { NewsletterSignup } from "@/components/newsletter-signup"
 import { getChannelStats } from "@/data-access/youtube"
 import { getContentFeed } from "@/data-access/content"
 import { formatNumber } from "@/lib/utils"
@@ -129,6 +130,10 @@ export default async function Home() {
             <ContentCard key={item.id} item={item} />
           ))}
         </div>
+      </section>
+
+      <section aria-label="Newsletter signup">
+        <NewsletterSignup />
       </section>
 
       <section aria-label="Channel membership">

--- a/src/components/newsletter-signup.tsx
+++ b/src/components/newsletter-signup.tsx
@@ -2,10 +2,15 @@
 
 import { useActionState, useId } from "react"
 import {
-  initialNewsletterState,
+  type NewsletterState,
   subscribeToNewsletterAction
 } from "@/app/actions"
 import { Diamond } from "@/components/icons"
+
+const initialNewsletterState: NewsletterState = {
+  status: "idle",
+  message: ""
+}
 
 type Props = {
   title?: string

--- a/src/components/newsletter-signup.tsx
+++ b/src/components/newsletter-signup.tsx
@@ -1,0 +1,77 @@
+"use client"
+
+import { useActionState, useId } from "react"
+import {
+  initialNewsletterState,
+  subscribeToNewsletterAction
+} from "@/app/actions"
+import { Diamond } from "@/components/icons"
+
+type Props = {
+  title?: string
+  description?: string
+}
+
+export function NewsletterSignup({
+  title = "Get notified",
+  description = "Join the list to hear about new YouTube videos, upcoming courses, and everything I'm building. No spam, unsubscribe anytime."
+}: Props) {
+  const [state, formAction, isPending] = useActionState(
+    subscribeToNewsletterAction,
+    initialNewsletterState
+  )
+  const emailId = useId()
+
+  return (
+    <div className="rounded-lg border border-violet-300/60 dark:border-violet-800/60 p-5 md:p-6">
+      <div className="flex items-start gap-4">
+        <div className="shrink-0 mt-0.5 text-violet-600 dark:text-violet-400">
+          <Diamond width={28} height={28} fill="currentColor" />
+        </div>
+        <div className="flex flex-col gap-1.5">
+          <span className="text-sm md:text-base font-bold">{title}</span>
+          <span className="text-xs md:text-sm opacity-50 leading-relaxed">
+            {description}
+          </span>
+        </div>
+      </div>
+
+      {state.status === "success" ? (
+        <p className="mt-4 text-sm text-emerald-600 dark:text-emerald-400">
+          {state.message}
+        </p>
+      ) : (
+        <form action={formAction} className="mt-4 flex flex-col gap-2">
+          <div className="flex flex-col sm:flex-row gap-2">
+            <label htmlFor={emailId} className="sr-only">
+              Email address
+            </label>
+            <input
+              id={emailId}
+              type="email"
+              name="email"
+              required
+              autoComplete="email"
+              placeholder="you@example.com"
+              disabled={isPending}
+              aria-invalid={state.status === "error"}
+              className="flex-1 rounded-sm border border-current/20 dark:border-current/30 bg-transparent px-3 py-2 text-sm outline-none focus:border-violet-500 dark:focus:border-violet-500 transition-colors disabled:opacity-50"
+            />
+            <button
+              type="submit"
+              disabled={isPending}
+              className="whitespace-nowrap rounded-sm bg-foreground px-4 py-2 text-xs uppercase tracking-widest text-background hover:opacity-80 transition-opacity disabled:opacity-50"
+            >
+              {isPending ? "Joining…" : "Subscribe"}
+            </button>
+          </div>
+          {state.status === "error" && (
+            <p className="text-xs text-red-600 dark:text-red-400">
+              {state.message}
+            </p>
+          )}
+        </form>
+      )}
+    </div>
+  )
+}

--- a/src/data-access/loops.ts
+++ b/src/data-access/loops.ts
@@ -1,0 +1,65 @@
+import { APIError, LoopsClient, RateLimitExceededError } from "loops"
+
+const API_KEY = process.env.LOOPS_API_KEY
+// Optional: if set, new subscribers are added to this Loops mailing list.
+// Leave unset to add them to the default audience only.
+const NEWSLETTER_LIST_ID = process.env.LOOPS_NEWSLETTER_LIST_ID
+
+// Reuse a single client across requests instead of constructing one per call.
+let client: LoopsClient | null = null
+
+function getClient(): LoopsClient {
+  if (!API_KEY) {
+    throw new Error("LOOPS_API_KEY is not set")
+  }
+  if (!client) {
+    client = new LoopsClient(API_KEY)
+  }
+  return client
+}
+
+export type SubscribeResult =
+  | { ok: true }
+  | { ok: false; reason: "rate_limited" | "error" }
+
+// Adds (or updates) a contact in Loops and marks them subscribed. Uses
+// updateContact, which upserts, so repeat signups from the same email don't
+// error out the way createContact would (409 on an existing contact).
+export async function subscribeToNewsletter(
+  email: string
+): Promise<SubscribeResult> {
+  try {
+    const loops = getClient()
+
+    await loops.updateContact({
+      email,
+      properties: {
+        subscribed: true,
+        // Built-in property used to segment where a contact came from.
+        userGroup: "Newsletter"
+      },
+      ...(NEWSLETTER_LIST_ID
+        ? { mailingLists: { [NEWSLETTER_LIST_ID]: true } }
+        : {})
+    })
+
+    return { ok: true }
+  } catch (error) {
+    if (error instanceof RateLimitExceededError) {
+      return { ok: false, reason: "rate_limited" }
+    }
+
+    // Surface the Loops status/message in server logs for debugging, but never
+    // leak provider details to the client.
+    if (error instanceof APIError) {
+      console.error(
+        `Loops API error (${error.statusCode}):`,
+        error.json ?? error.rawBody
+      )
+    } else {
+      console.error("Loops subscribe failed:", error)
+    }
+
+    return { ok: false, reason: "error" }
+  }
+}

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -1,6 +1,11 @@
 import assert from "node:assert/strict"
 import { test } from "node:test"
-import { formatDuration, formatNumber, parseIsoDuration } from "./utils.ts"
+import {
+  formatDuration,
+  formatNumber,
+  isValidEmail,
+  parseIsoDuration
+} from "./utils.ts"
 
 test("formatNumber abbreviates thousands and millions", () => {
   assert.equal(formatNumber(950), "950")
@@ -15,6 +20,23 @@ test("formatDuration formats mm:ss and h:mm:ss", () => {
   assert.equal(formatDuration(977), "16:17")
   assert.equal(formatDuration(3723), "1:02:03")
   assert.equal(formatDuration(60), "1:00")
+})
+
+test("isValidEmail accepts well-formed addresses", () => {
+  assert.equal(isValidEmail("user@example.com"), true)
+  assert.equal(isValidEmail("first.last@sub.domain.co"), true)
+  assert.equal(isValidEmail("  spaced@example.com  "), true)
+})
+
+test("isValidEmail rejects malformed input", () => {
+  assert.equal(isValidEmail(""), false)
+  assert.equal(isValidEmail("   "), false)
+  assert.equal(isValidEmail("nope"), false)
+  assert.equal(isValidEmail("nope@"), false)
+  assert.equal(isValidEmail("@example.com"), false)
+  assert.equal(isValidEmail("no@dot"), false)
+  assert.equal(isValidEmail("two@@example.com"), false)
+  assert.equal(isValidEmail("spaces in@example.com"), false)
 })
 
 test("parseIsoDuration parses ISO-8601 durations", () => {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -37,6 +37,15 @@ export function formatDuration(seconds: number): string {
   return h > 0 ? `${h}:${pad(m)}:${pad(s)}` : `${m}:${pad(s)}`
 }
 
+// Basic email shape check for the newsletter form. Kept deliberately simple:
+// real validity is confirmed by Loops (and by the user receiving the email),
+// so this only rejects obviously malformed input before we hit the API.
+export function isValidEmail(email: string): boolean {
+  const trimmed = email.trim()
+  if (trimmed.length === 0 || trimmed.length > 320) return false
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(trimmed)
+}
+
 // ISO-8601 video duration ("PT16M17S", "PT1H2M3S") -> seconds.
 export function parseIsoDuration(iso: string): number {
   const match = iso.match(/PT(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?/)


### PR DESCRIPTION
## Summary

Adds an email newsletter signup so visitors can subscribe to hear about new YouTube videos and upcoming (paid) courses. Powered by [Loops](https://loops.so).

- **Server-side Loops wrapper** (`src/data-access/loops.ts`) using the official `loops` JS SDK. Uses `updateContact` (upsert) so repeat signups don't error, marks the contact `subscribed`, tags `userGroup: "Newsletter"`, and optionally adds them to a mailing list. Provider errors are logged server-side, never leaked to the client.
- **Server Action** (`src/app/actions.ts`) that validates the email and returns friendly success/error/rate-limit states.
- **Pure `isValidEmail` helper** added to `src/lib/utils.ts` with unit tests (keeps validation logic I/O-free per repo conventions).
- **`NewsletterSignup` client component** using React 19 `useActionState`, styled to match the existing `MembershipCTA` (violet accent, Diamond icon). Shows pending/success/error states.
- **Placement**: home page (general message) and courses page (early-access/launch message).
- **Env & docs**: `LOOPS_API_KEY` and optional `LOOPS_NEWSLETTER_LIST_ID` added to `.env.example` and documented in the README.

## Setup required before it works

- Generate a key in Loops (**Settings → API**) and set `LOOPS_API_KEY`. Until set, the form returns a graceful error (the build does not depend on it).
- Optional: set `LOOPS_NEWSLETTER_LIST_ID` to add signups to a specific mailing list; otherwise they go to the default audience.

## Test plan

- [x] `npm run format`
- [x] `npm run check` (lint + typecheck)
- [x] `npm test` (16/16 pass, incl. new `isValidEmail` tests)
- [x] `npm run build` (static prerender + ISR intact)
- [ ] Set `LOOPS_API_KEY`, submit the form, confirm the contact appears in Loops
- [ ] Verify invalid emails and duplicate submissions are handled gracefully

Made with [Cursor](https://cursor.com)