### PR TITLE
Improve site UX: accessibility, loading states, and navigation polish

### DIFF
--- a/src/app/courses/loading.tsx
+++ b/src/app/courses/loading.tsx
@@ -1,0 +1,5 @@
+import { CoursesLoadingSkeleton } from "@/components/skeletons"
+
+export default function Loading() {
+  return <CoursesLoadingSkeleton />
+}

--- a/src/app/courses/page.tsx
+++ b/src/app/courses/page.tsx
@@ -41,29 +41,70 @@ export default async function Courses() {
   const { englishCourses, portugueseCourses } = await getCourses()
 
   return (
-    <main className="my-14 md:my-28 max-w-[978px] mx-auto flex flex-col">
+    <main
+      id="main"
+      className="my-14 md:my-28 max-w-[978px] mx-auto flex flex-col"
+    >
       <h1 className="font-serif text-3xl md:text-4xl italic tracking-tight mb-4">
         Courses
       </h1>
+      <p className="text-sm md:text-base leading-relaxed opacity-60 mb-4 max-w-2xl">
+        Free fullstack web development playlists on YouTube. Start with the
+        English courses or browse the Portuguese catalog below.
+      </p>
       <hr className="w-12 border-t border-current opacity-20 mb-6 md:mb-8" />
 
-      <div className="flex flex-col items-center sm:items-stretch gap-4">
-        {englishCourses.map((playlist, index) => (
-          <Video
-            video={playlist}
-            key={playlist.id}
-            newCourse={index === 0}
-            locale="en"
-            featured
-          />
-        ))}
-      </div>
+      <section
+        aria-labelledby="english-courses-heading"
+        className="flex flex-col gap-4"
+      >
+        <h2
+          id="english-courses-heading"
+          className="font-serif text-xl md:text-2xl italic tracking-tight"
+        >
+          English courses
+        </h2>
+        {englishCourses.length === 0 ? (
+          <p className="opacity-60 text-sm md:text-base">
+            No English courses available right now. Check back soon.
+          </p>
+        ) : (
+          <div className="flex flex-col items-center sm:items-stretch gap-4">
+            {englishCourses.map((playlist, index) => (
+              <Video
+                video={playlist}
+                key={playlist.id}
+                newCourse={index === 0}
+                locale="en"
+                featured
+              />
+            ))}
+          </div>
+        )}
+      </section>
 
-      <div className="flex flex-wrap gap-4 justify-center lg:justify-between mt-4 sm:mt-6">
-        {portugueseCourses.map((playlist) => (
-          <Video video={playlist} key={playlist.id} locale="pt" />
-        ))}
-      </div>
+      <section
+        aria-labelledby="portuguese-courses-heading"
+        className="flex flex-col gap-4 mt-10 md:mt-12"
+      >
+        <h2
+          id="portuguese-courses-heading"
+          className="font-serif text-xl md:text-2xl italic tracking-tight"
+        >
+          Cursos em português
+        </h2>
+        {portugueseCourses.length === 0 ? (
+          <p className="opacity-60 text-sm md:text-base">
+            No Portuguese courses available right now. Check back soon.
+          </p>
+        ) : (
+          <div className="flex flex-wrap gap-4 justify-center lg:justify-between">
+            {portugueseCourses.map((playlist) => (
+              <Video video={playlist} key={playlist.id} locale="pt" />
+            ))}
+          </div>
+        )}
+      </section>
     </main>
   )
 }

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,0 +1,46 @@
+"use client"
+
+import { useEffect } from "react"
+
+// biome-ignore lint/suspicious/noShadowRestrictedNames: Next.js error boundary convention
+export default function Error({
+  error,
+  reset
+}: {
+  error: Error & { digest?: string }
+  reset: () => void
+}) {
+  useEffect(() => {
+    console.error(error)
+  }, [error])
+
+  return (
+    <main
+      id="main"
+      className="my-14 md:my-28 max-w-2xl mx-auto flex flex-col gap-5 text-left"
+    >
+      <h1 className="font-serif text-3xl md:text-4xl italic tracking-tight">
+        Something went wrong
+      </h1>
+      <p className="text-sm md:text-base leading-relaxed opacity-60">
+        We couldn&apos;t load this page right now. This is usually temporary —
+        try again in a moment.
+      </p>
+      <div className="flex flex-wrap gap-4">
+        <button
+          type="button"
+          onClick={reset}
+          className="inline-flex items-center justify-center min-h-11 rounded-sm bg-foreground px-5 py-2.5 text-xs uppercase tracking-widest text-background hover:opacity-80 transition-opacity"
+        >
+          Try again
+        </button>
+        <a
+          href="/"
+          className="inline-flex items-center justify-center min-h-11 rounded-sm border border-current/30 px-5 py-2.5 text-xs uppercase tracking-widest hover:border-current/60 transition-colors"
+        >
+          Go home
+        </a>
+      </div>
+    </main>
+  )
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -23,6 +23,30 @@
   ::file-selector-button {
     border-color: var(--color-gray-200, currentColor);
   }
+
+  :focus {
+    outline: none;
+  }
+
+  :focus-visible {
+    outline: 2px solid rgb(var(--foreground-rgb));
+    outline-offset: 2px;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    *,
+    ::before,
+    ::after {
+      /* biome-ignore lint/complexity/noImportantStyles: required to override Tailwind animations */
+      animation-duration: 0.01ms !important;
+      /* biome-ignore lint/complexity/noImportantStyles: required to override Tailwind animations */
+      animation-iteration-count: 1 !important;
+      /* biome-ignore lint/complexity/noImportantStyles: required to override Tailwind animations */
+      transition-duration: 0.01ms !important;
+      /* biome-ignore lint/complexity/noImportantStyles: required to override Tailwind animations */
+      scroll-behavior: auto !important;
+    }
+  }
 }
 
 @layer utilities {
@@ -41,5 +65,26 @@
   body {
     color: rgb(var(--foreground-rgb));
     background: rgb(var(--background-rgb));
+  }
+
+  .skip-link {
+    position: absolute;
+    top: 0.5rem;
+    left: 0.5rem;
+    z-index: 100;
+    padding: 0.5rem 1rem;
+    background: rgb(var(--background-rgb));
+    color: rgb(var(--foreground-rgb));
+    border: 1px solid rgb(var(--foreground-rgb) / 0.2);
+    border-radius: 0.25rem;
+    font-size: 0.875rem;
+    text-transform: uppercase;
+    letter-spacing: 0.15em;
+    transform: translateY(-200%);
+    transition: transform 0.2s ease;
+  }
+
+  .skip-link:focus {
+    transform: translateY(0);
   }
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next"
 import { Instrument_Serif, Poppins } from "next/font/google"
 
+import { Footer } from "@/components/footer"
 import { Nav } from "@/components/nav"
 import "./globals.css"
 
@@ -129,7 +130,16 @@ export default function RootLayout({
         {/* SEO Meta Tags */}
         <link rel="sitemap" href="/sitemap.xml" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
-        <link rel="manifest" href="/site.webmanifest" />
+        <meta
+          name="theme-color"
+          content="#ffffff"
+          media="(prefers-color-scheme: light)"
+        />
+        <meta
+          name="theme-color"
+          content="#000000"
+          media="(prefers-color-scheme: dark)"
+        />
         <meta name="color-scheme" content="light dark" />
 
         {/* Structured Data */}
@@ -151,8 +161,12 @@ export default function RootLayout({
       <body
         className={`${poppins.className} ${instrumentSerif.variable} px-6 md:px-10 py-5 md:py-6`}
       >
+        <a href="#main" className="skip-link">
+          Skip to content
+        </a>
         <Nav />
         {children}
+        <Footer />
       </body>
     </html>
   )

--- a/src/app/links/page.tsx
+++ b/src/app/links/page.tsx
@@ -19,7 +19,7 @@ export const metadata: Metadata = {
 
 export default function Links() {
   return (
-    <main className="my-14 md:my-28">
+    <main id="main" className="my-14 md:my-28">
       <div className="flex flex-col items-center mb-6 md:mb-8">
         <h1 className="font-serif text-3xl md:text-4xl italic tracking-tight">
           Links

--- a/src/app/loading.tsx
+++ b/src/app/loading.tsx
@@ -1,0 +1,5 @@
+import { HomeLoadingSkeleton } from "@/components/skeletons"
+
+export default function Loading() {
+  return <HomeLoadingSkeleton />
+}

--- a/src/app/manifest.ts
+++ b/src/app/manifest.ts
@@ -1,0 +1,29 @@
+import type { MetadataRoute } from "next"
+
+export default function manifest(): MetadataRoute.Manifest {
+  return {
+    name: "Daniel Bergholz - Software Engineer & Solopreneur",
+    short_name: "Daniel Bergholz",
+    description:
+      "Software Engineer, Content Creator and Solopreneur from Brazil",
+    icons: [
+      {
+        src: "/android-chrome-192x192.png",
+        sizes: "192x192",
+        type: "image/png"
+      },
+      {
+        src: "/android-chrome-512x512.png",
+        sizes: "512x512",
+        type: "image/png"
+      }
+    ],
+    theme_color: "#ffffff",
+    background_color: "#ffffff",
+    display: "standalone",
+    start_url: "/",
+    scope: "/",
+    lang: "en",
+    orientation: "portrait-primary"
+  }
+}

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -2,7 +2,10 @@ import Link from "next/link"
 
 export default function NotFound() {
   return (
-    <main className="text-left w-auto md:w-[500px] mx-auto my-48 md:my-56 flex flex-col gap-3">
+    <main
+      id="main"
+      className="text-left w-auto md:w-[500px] mx-auto my-48 md:my-56 flex flex-col gap-3"
+    >
       <h1 className="text-2xl md:text-3xl font-bold">Whoops 👀</h1>
       <h2 className="text-base md:text-xl">
         It seems like you&apos;re lost, let me help you find your way back

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -16,7 +16,10 @@ export default async function Home() {
   const latestVideos = content.filter((item) => item.videoUrl).slice(0, 3)
 
   return (
-    <main className="my-14 md:my-28 max-w-4xl mx-auto flex flex-col gap-14 md:gap-20">
+    <main
+      id="main"
+      className="my-14 md:my-28 max-w-4xl mx-auto flex flex-col gap-14 md:gap-20"
+    >
       <section className="w-auto md:w-[560px] mx-auto flex flex-col gap-5 text-left">
         <h1 className="font-serif text-4xl md:text-5xl italic tracking-tight">
           Hello
@@ -28,14 +31,12 @@ export default async function Home() {
           Brazil
         </h2>
         <a
-          className="group w-max text-xs md:text-sm uppercase tracking-widest opacity-50 hover:opacity-100 transition-opacity duration-300"
+          className="group w-max text-xs md:text-sm uppercase tracking-widest opacity-50 hover:opacity-100 transition-opacity duration-300 motion-reduce:transition-none"
           href="mailto:bergholz.daniel@gmail.com"
-          title="Send email to Daniel Bergholz"
-          target="_blank"
-          rel="noreferrer noopener"
+          aria-label="Get in touch via email"
         >
           Get in touch{" "}
-          <span className="inline-block transition-transform duration-300 group-hover:translate-x-1">
+          <span className="inline-block transition-transform duration-300 motion-reduce:transition-none group-hover:translate-x-1 motion-reduce:group-hover:translate-x-0">
             &rarr;
           </span>
         </a>
@@ -45,42 +46,42 @@ export default async function Home() {
         <section aria-label="Social Media" className="flex items-center gap-4">
           <a
             href="https://www.youtube.com/@DanielBergholz"
-            title="YouTube"
+            aria-label="YouTube"
             target="_blank"
             rel="noreferrer noopener"
-            className="opacity-60 hover:opacity-100 hover:scale-110 transition-all duration-300"
+            className="opacity-60 hover:opacity-100 hover:scale-110 motion-reduce:hover:scale-100 transition-all duration-300 motion-reduce:transition-none"
           >
-            <YouTube width={24} height={24} />
+            <YouTube width={24} height={24} aria-hidden />
           </a>
 
           <a
             href="https://twitter.com/danielbergholz"
-            title="X (Formerly Twitter)"
+            aria-label="X (formerly Twitter)"
             target="_blank"
             rel="noreferrer noopener"
-            className="opacity-60 hover:opacity-100 hover:scale-110 transition-all duration-300"
+            className="opacity-60 hover:opacity-100 hover:scale-110 motion-reduce:hover:scale-100 transition-all duration-300 motion-reduce:transition-none"
           >
-            <Twitter width={20} height={20} />
+            <Twitter width={20} height={20} aria-hidden />
           </a>
 
           <a
             href="https://www.linkedin.com/in/daniel-gobbi-bergholz/"
-            title="LinkedIn"
+            aria-label="LinkedIn"
             target="_blank"
             rel="noreferrer noopener"
-            className="opacity-60 hover:opacity-100 hover:scale-110 transition-all duration-300"
+            className="opacity-60 hover:opacity-100 hover:scale-110 motion-reduce:hover:scale-100 transition-all duration-300 motion-reduce:transition-none"
           >
-            <LinkedIn width={21} height={21} />
+            <LinkedIn width={21} height={21} aria-hidden />
           </a>
 
           <a
             href="https://github.com/danielbergholz"
-            title="GitHub"
+            aria-label="GitHub"
             target="_blank"
             rel="noreferrer noopener"
-            className="opacity-60 hover:opacity-100 hover:scale-110 transition-all duration-300"
+            className="opacity-60 hover:opacity-100 hover:scale-110 motion-reduce:hover:scale-100 transition-all duration-300 motion-reduce:transition-none"
           >
-            <GitHub width={24} height={24} />
+            <GitHub width={24} height={24} aria-hidden />
           </a>
         </section>
 
@@ -92,7 +93,7 @@ export default async function Home() {
             <span className="text-2xl md:text-3xl font-bold tracking-tight">
               {formatNumber(subscriberCount)}+
             </span>
-            <span className="text-[10px] md:text-xs uppercase tracking-[0.2em] opacity-40">
+            <span className="text-[10px] md:text-xs uppercase tracking-[0.2em] opacity-60">
               Subscribers
             </span>
           </div>
@@ -101,7 +102,7 @@ export default async function Home() {
             <span className="text-2xl md:text-3xl font-bold tracking-tight">
               {formatNumber(viewCount)}+
             </span>
-            <span className="text-[10px] md:text-xs uppercase tracking-[0.2em] opacity-40">
+            <span className="text-[10px] md:text-xs uppercase tracking-[0.2em] opacity-60">
               Views
             </span>
           </div>
@@ -116,19 +117,29 @@ export default async function Home() {
           <Link
             href="/videos"
             title="See all videos and articles"
-            className="group whitespace-nowrap text-xs md:text-sm uppercase tracking-widest opacity-50 hover:opacity-100 transition-opacity duration-300"
+            className="group whitespace-nowrap text-xs md:text-sm uppercase tracking-widest opacity-50 hover:opacity-100 transition-opacity duration-300 motion-reduce:transition-none"
           >
             View all{" "}
-            <span className="inline-block transition-transform duration-300 group-hover:translate-x-1">
+            <span className="inline-block transition-transform duration-300 motion-reduce:transition-none group-hover:translate-x-1 motion-reduce:group-hover:translate-x-0">
               &rarr;
             </span>
           </Link>
         </div>
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-          {latestVideos.map((item) => (
-            <ContentCard key={item.id} item={item} />
-          ))}
-        </div>
+        {latestVideos.length === 0 ? (
+          <p className="opacity-60 text-sm md:text-base">
+            No videos available right now. Check back soon or browse{" "}
+            <Link href="/videos" className="underline underline-offset-2">
+              all content
+            </Link>
+            .
+          </p>
+        ) : (
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+            {latestVideos.map((item, index) => (
+              <ContentCard key={item.id} item={item} priority={index === 0} />
+            ))}
+          </div>
+        )}
       </section>
 
       <section aria-label="Channel membership">

--- a/src/app/products/page.tsx
+++ b/src/app/products/page.tsx
@@ -21,7 +21,7 @@ export const metadata: Metadata = {
 
 export default function Products() {
   return (
-    <main className="w-auto md:max-w-3xl mx-auto my-14 md:my-28">
+    <main id="main" className="w-auto md:max-w-3xl mx-auto my-14 md:my-28">
       <h1 className="font-serif text-3xl md:text-4xl italic tracking-tight mb-4">
         Products
       </h1>
@@ -64,7 +64,7 @@ export default function Products() {
             <h3 className="text-sm font-semibold mb-2 tracking-wide">
               What CourseShelf offers:
             </h3>
-            <ul className="list-disc list-inside space-y-1 opacity-40 text-sm">
+            <ul className="list-disc list-inside space-y-1 opacity-60 text-sm">
               <li>Community-driven course reviews and recommendations</li>
               <li>Personal learning library and playlist creation</li>
               <li>Courses across all subjects - from coding to cooking</li>
@@ -111,7 +111,7 @@ export default function Products() {
             <h3 className="text-sm font-semibold mb-2 tracking-wide">
               What TechSchool offers:
             </h3>
-            <ul className="list-disc list-inside space-y-1 opacity-40 text-sm">
+            <ul className="list-disc list-inside space-y-1 opacity-60 text-sm">
               <li>
                 189+ curated free courses in multiple programming languages
               </li>

--- a/src/app/videos/loading.tsx
+++ b/src/app/videos/loading.tsx
@@ -1,0 +1,5 @@
+import { VideosLoadingSkeleton } from "@/components/skeletons"
+
+export default function Loading() {
+  return <VideosLoadingSkeleton />
+}

--- a/src/app/videos/page.tsx
+++ b/src/app/videos/page.tsx
@@ -45,7 +45,7 @@ export default async function Videos() {
   const items = await getContentFeed()
 
   return (
-    <main className="my-14 md:my-28 max-w-5xl mx-auto flex flex-col">
+    <main id="main" className="my-14 md:my-28 max-w-5xl mx-auto flex flex-col">
       <h1 className="font-serif text-3xl md:text-4xl italic tracking-tight mb-4">
         Videos
       </h1>

--- a/src/app/work-with-me/page.tsx
+++ b/src/app/work-with-me/page.tsx
@@ -107,7 +107,7 @@ export default async function WorkWithMe() {
   ]
 
   return (
-    <main className="w-auto md:max-w-3xl mx-auto my-14 md:my-28">
+    <main id="main" className="w-auto md:max-w-3xl mx-auto my-14 md:my-28">
       <h1 className="font-serif text-3xl md:text-4xl italic tracking-tight mb-3">
         Work with me
       </h1>
@@ -137,7 +137,7 @@ export default async function WorkWithMe() {
               {service.description}
             </p>
 
-            <ul className="list-disc list-inside space-y-1 opacity-40 text-sm">
+            <ul className="list-disc list-inside space-y-1 opacity-60 text-sm">
               {service.highlights.map((item) => (
                 <li key={item}>{item}</li>
               ))}
@@ -167,7 +167,7 @@ export default async function WorkWithMe() {
                   &rarr;
                 </span>
               </span>
-              <span className="text-sm opacity-40 group-hover:opacity-60 transition-opacity">
+              <span className="text-sm opacity-60 group-hover:opacity-80 transition-opacity">
                 {item.role}
               </span>
             </a>

--- a/src/components/content-card.tsx
+++ b/src/components/content-card.tsx
@@ -4,14 +4,16 @@ import { formatDuration, readableDate } from "@/lib/utils"
 import Image from "next/image"
 
 const CARD_BASE =
-  "group flex rounded-lg border border-current/10 dark:border-current/20 hover:border-current/30 dark:hover:border-current/40 transition-all duration-300"
+  "group flex rounded-lg border border-current/10 dark:border-current/20 hover:border-current/30 dark:hover:border-current/40 transition-all duration-300 motion-reduce:transition-none"
 
 function Thumbnail({
   item,
-  featured
+  featured,
+  priority = false
 }: {
   item: ContentItem
   featured: boolean
+  priority?: boolean
 }) {
   const { title, thumbnailUrl, videoUrl, articleUrl, durationSeconds } = item
   const isArticleOnly = !videoUrl && !!articleUrl
@@ -22,6 +24,7 @@ function Thumbnail({
         src={thumbnailUrl}
         alt={title}
         fill
+        priority={priority}
         sizes={
           featured
             ? "(max-width: 768px) 100vw, 440px"
@@ -35,9 +38,9 @@ function Thumbnail({
         </span>
       )}
       {videoUrl && (
-        <span className="absolute inset-0 flex items-center justify-center">
+        <span className="absolute inset-0 flex items-center justify-center pointer-events-none">
           <span
-            className={`flex items-center justify-center rounded-full bg-black/55 text-white transition-transform duration-300 group-hover:scale-110 ${
+            className={`flex items-center justify-center rounded-full bg-black/55 text-white transition-transform duration-300 motion-reduce:transition-none group-hover:scale-110 motion-reduce:group-hover:scale-100 ${
               featured ? "h-16 w-16" : "h-11 w-11"
             }`}
           >
@@ -57,6 +60,9 @@ function Thumbnail({
 function Actions({ item, featured }: { item: ContentItem; featured: boolean }) {
   const { videoUrl, articleUrl, readingMinutes } = item
 
+  const compactActionClass =
+    "inline-flex items-center justify-center gap-1 rounded-sm border border-current/20 min-h-11 px-3 py-2 text-[11px] uppercase tracking-wide opacity-70 hover:opacity-100 transition-opacity md:min-h-0 md:px-2 md:py-1"
+
   if (featured) {
     return (
       <div className="flex flex-wrap items-center gap-3">
@@ -65,7 +71,7 @@ function Actions({ item, featured }: { item: ContentItem; featured: boolean }) {
             href={videoUrl}
             target="_blank"
             rel="noreferrer noopener"
-            className="inline-flex items-center gap-2 rounded-sm bg-foreground px-4 py-2 text-xs uppercase tracking-widest text-background hover:opacity-80 transition-opacity"
+            className="inline-flex items-center justify-center gap-2 rounded-sm bg-foreground min-h-11 px-4 py-2.5 text-xs uppercase tracking-widest text-background hover:opacity-80 transition-opacity"
           >
             <Play width={14} height={14} /> Watch
           </a>
@@ -75,7 +81,7 @@ function Actions({ item, featured }: { item: ContentItem; featured: boolean }) {
             href={articleUrl}
             target="_blank"
             rel="noreferrer noopener"
-            className="inline-flex items-center gap-2 rounded-sm border border-current/30 px-4 py-2 text-xs uppercase tracking-widest hover:border-current/60 transition-colors"
+            className="inline-flex items-center justify-center gap-2 rounded-sm border border-current/30 min-h-11 px-4 py-2.5 text-xs uppercase tracking-widest hover:border-current/60 transition-colors"
           >
             <Read width={14} height={14} /> Read
           </a>
@@ -91,7 +97,7 @@ function Actions({ item, featured }: { item: ContentItem; featured: boolean }) {
           href={videoUrl}
           target="_blank"
           rel="noreferrer noopener"
-          className="inline-flex items-center gap-1 rounded-sm border border-current/20 px-2 py-1 text-[11px] uppercase tracking-wide opacity-70 hover:opacity-100 transition-opacity"
+          className={compactActionClass}
         >
           <Play width={12} height={12} /> Watch
         </a>
@@ -101,7 +107,7 @@ function Actions({ item, featured }: { item: ContentItem; featured: boolean }) {
           href={articleUrl}
           target="_blank"
           rel="noreferrer noopener"
-          className="inline-flex items-center gap-1 rounded-sm border border-current/20 px-2 py-1 text-[11px] uppercase tracking-wide opacity-70 hover:opacity-100 transition-opacity"
+          className={compactActionClass}
         >
           <Read width={12} height={12} /> Read
           {readingMinutes != null && (
@@ -116,9 +122,14 @@ function Actions({ item, featured }: { item: ContentItem; featured: boolean }) {
 type Props = {
   item: ContentItem
   featured?: boolean
+  priority?: boolean
 }
 
-export function ContentCard({ item, featured = false }: Props) {
+export function ContentCard({
+  item,
+  featured = false,
+  priority = false
+}: Props) {
   const { title, date, description, readingMinutes, videoUrl, articleUrl } =
     item
 
@@ -138,7 +149,7 @@ export function ContentCard({ item, featured = false }: Props) {
           title={title}
           className="block md:w-[440px] md:shrink-0"
         >
-          <Thumbnail item={item} featured />
+          <Thumbnail item={item} featured priority={priority} />
         </a>
         <div className="flex flex-1 flex-col gap-3">
           <a
@@ -156,7 +167,7 @@ export function ContentCard({ item, featured = false }: Props) {
               {description}
             </p>
           )}
-          <div className="flex flex-wrap items-center gap-x-2 text-xs uppercase tracking-widest opacity-40">
+          <div className="flex flex-wrap items-center gap-x-2 text-xs uppercase tracking-widest opacity-60">
             <span>{readableDate(date)}</span>
             {readingMinutes != null && <span>· {readingMinutes} min read</span>}
           </div>
@@ -177,13 +188,13 @@ export function ContentCard({ item, featured = false }: Props) {
         title={title}
         className="flex flex-col gap-3"
       >
-        <Thumbnail item={item} featured={false} />
+        <Thumbnail item={item} featured={false} priority={priority} />
         <h2 className="font-bold text-base md:text-lg leading-snug line-clamp-2 group-hover:opacity-80 transition-opacity">
           {title}
         </h2>
       </a>
       <div className="flex items-center justify-between gap-2">
-        <span className="text-xs uppercase tracking-widest opacity-40">
+        <span className="text-xs uppercase tracking-widest opacity-60">
           {readableDate(date)}
         </span>
         <Actions item={item} featured={false} />

--- a/src/components/content-feed.tsx
+++ b/src/components/content-feed.tsx
@@ -1,9 +1,10 @@
 "use client"
 
 import { useRouter, useSearchParams } from "next/navigation"
-import { Suspense, useEffect, useRef, useState } from "react"
+import { Suspense, useEffect, useId, useRef, useState } from "react"
 
 import { ContentCard } from "@/components/content-card"
+import { ContentFeedSkeleton } from "@/components/skeletons"
 import type { ContentItem } from "@/lib/types"
 
 type Props = {
@@ -22,14 +23,24 @@ function matches(item: ContentItem, query: string): boolean {
 
 function SearchInput({
   value,
-  onChange
+  onChange,
+  onClear
 }: {
   value: string
   onChange: (value: string) => void
+  onClear: () => void
 }) {
+  const inputId = useId()
+
   return (
     <div className="relative w-full">
-      <span className="absolute left-3 top-1/2 -translate-y-1/2 opacity-40 pointer-events-none">
+      <label htmlFor={inputId} className="sr-only">
+        Search videos and articles
+      </label>
+      <span
+        className="absolute left-3 top-1/2 -translate-y-1/2 opacity-60 pointer-events-none"
+        aria-hidden="true"
+      >
         <svg
           xmlns="http://www.w3.org/2000/svg"
           width="18"
@@ -38,8 +49,8 @@ function SearchInput({
           viewBox="0 0 24 24"
           strokeWidth={2}
           stroke="currentColor"
-          role="img"
-          aria-label="Search"
+          aria-hidden="true"
+          focusable="false"
         >
           <path
             strokeLinecap="round"
@@ -49,13 +60,39 @@ function SearchInput({
         </svg>
       </span>
       <input
+        id={inputId}
         type="search"
         value={value}
         onChange={(event) => onChange(event.target.value)}
         placeholder="Search videos and articles..."
         aria-label="Search videos and articles"
-        className="w-full rounded-lg border border-current/10 dark:border-current/20 bg-transparent pl-10 pr-4 py-2.5 text-sm md:text-base outline-none focus:border-current/30 dark:focus:border-current/40 transition-colors"
+        className="w-full rounded-lg border border-current/10 dark:border-current/20 bg-transparent pl-10 pr-10 py-2.5 text-sm md:text-base focus:border-current/30 dark:focus:border-current/40 transition-colors"
       />
+      {value.length > 0 && (
+        <button
+          type="button"
+          onClick={onClear}
+          className="absolute right-2 top-1/2 -translate-y-1/2 flex items-center justify-center w-8 h-8 rounded-sm opacity-60 hover:opacity-100 transition-opacity"
+          aria-label="Clear search"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="16"
+            height="16"
+            fill="none"
+            viewBox="0 0 24 24"
+            strokeWidth={2}
+            stroke="currentColor"
+            aria-hidden="true"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M6 18 18 6M6 6l12 12"
+            />
+          </svg>
+        </button>
+      )}
     </div>
   )
 }
@@ -67,6 +104,7 @@ function ContentFeedInner({ items }: Props) {
 
   const [inputValue, setInputValue] = useState(queryFromUrl)
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const resultsId = useId()
 
   // Keep input in sync when navigating back/forward. Skip when the URL already
   // reflects the current input so the visible value doesn't shift mid-typing.
@@ -97,6 +135,12 @@ function ContentFeedInner({ items }: Props) {
     }, 300)
   }
 
+  const handleClear = () => {
+    setInputValue("")
+    if (debounceRef.current) clearTimeout(debounceRef.current)
+    updateUrl("")
+  }
+
   useEffect(() => {
     return () => {
       if (debounceRef.current) clearTimeout(debounceRef.current)
@@ -108,19 +152,47 @@ function ContentFeedInner({ items }: Props) {
     ? items.filter((item) => matches(item, inputValue))
     : items
 
+  const resultSummary = isSearching
+    ? filtered.length === 0
+      ? `No results for "${inputValue.trim()}"`
+      : `${filtered.length} result${filtered.length === 1 ? "" : "s"} for "${inputValue.trim()}"`
+    : ""
+
   return (
     <div className="flex flex-col gap-5">
-      <SearchInput value={inputValue} onChange={handleChange} />
+      <SearchInput
+        value={inputValue}
+        onChange={handleChange}
+        onClear={handleClear}
+      />
+
+      <p
+        id={resultsId}
+        className="sr-only"
+        aria-live="polite"
+        aria-atomic="true"
+      >
+        {resultSummary}
+      </p>
+
       {filtered.length === 0 ? (
-        <p className="opacity-50 text-sm md:text-base">
+        <p className="opacity-60 text-sm md:text-base" role="status">
           No results for &ldquo;{inputValue.trim()}&rdquo;.
         </p>
       ) : isSearching ? (
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-          {filtered.map((item) => (
-            <ContentCard key={item.id} item={item} />
-          ))}
-        </div>
+        <>
+          <p
+            className="text-xs uppercase tracking-widest opacity-60"
+            aria-hidden="true"
+          >
+            {filtered.length} result{filtered.length === 1 ? "" : "s"}
+          </p>
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+            {filtered.map((item) => (
+              <ContentCard key={item.id} item={item} />
+            ))}
+          </div>
+        </>
       ) : (
         <>
           <div className="flex flex-col gap-4">
@@ -143,7 +215,7 @@ function ContentFeedInner({ items }: Props) {
 
 export function ContentFeed(props: Props) {
   return (
-    <Suspense fallback={null}>
+    <Suspense fallback={<ContentFeedSkeleton />}>
       <ContentFeedInner {...props} />
     </Suspense>
   )

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -1,3 +1,4 @@
+import { ExternalLink } from "@/components/icons"
 import Link from "next/link"
 
 const footerLinks = [
@@ -15,7 +16,7 @@ const socialLinks = [
   },
   {
     href: "https://twitter.com/danielbergholz",
-    label: "X (Twitter)"
+    label: "X"
   },
   {
     href: "https://www.linkedin.com/in/daniel-gobbi-bergholz/",
@@ -27,56 +28,71 @@ const socialLinks = [
   }
 ]
 
+const sectionLabel =
+  "mb-3 text-[10px] uppercase tracking-[0.2em] text-foreground/50"
+
+const internalLinkStyle =
+  "text-sm normal-case tracking-normal font-medium text-foreground/60 hover:text-foreground transition-colors"
+
+const externalLinkStyle =
+  "inline-flex items-center gap-1.5 text-xs uppercase tracking-[0.15em] text-foreground/60 hover:text-foreground border border-current/15 dark:border-current/25 rounded-sm px-2.5 py-1.5 transition-colors"
+
 export function Footer() {
   return (
     <footer className="mt-20 md:mt-28 pt-8 border-t border-current/10 dark:border-current/20">
       <div className="max-w-5xl mx-auto flex flex-col gap-8 md:gap-10">
-        <div className="flex flex-col md:flex-row md:items-start md:justify-between gap-8">
+        <div className="flex flex-col lg:flex-row lg:items-start lg:justify-between gap-8">
           <div className="flex flex-col gap-3">
             <p className="font-bold text-sm uppercase tracking-[0.15em]">
               Daniel Bergholz
             </p>
             <a
               href="mailto:bergholz.daniel@gmail.com"
-              className="text-sm opacity-60 hover:opacity-100 transition-opacity w-max"
+              className="text-sm text-foreground/60 hover:text-foreground transition-colors w-max"
             >
               bergholz.daniel@gmail.com
             </a>
           </div>
 
-          <nav aria-label="Footer">
-            <ul className="flex flex-wrap gap-x-6 gap-y-2 text-xs uppercase tracking-[0.2em]">
-              {footerLinks.map(({ href, label }) => (
-                <li key={href}>
-                  <Link
-                    href={href}
-                    className="opacity-60 hover:opacity-100 transition-opacity"
-                  >
-                    {label}
-                  </Link>
-                </li>
-              ))}
-            </ul>
-          </nav>
+          <div className="flex flex-col sm:flex-row gap-8 sm:gap-12 lg:gap-16">
+            <nav aria-label="Site pages">
+              <p className={sectionLabel}>Pages</p>
+              <ul className="flex flex-col gap-2.5">
+                {footerLinks.map(({ href, label }) => (
+                  <li key={href}>
+                    <Link href={href} className={internalLinkStyle}>
+                      {label}
+                    </Link>
+                  </li>
+                ))}
+              </ul>
+            </nav>
+
+            <nav aria-label="Social media">
+              <p className={sectionLabel}>Social</p>
+              <ul className="flex flex-col gap-2.5">
+                {socialLinks.map(({ href, label }) => (
+                  <li key={href}>
+                    <a
+                      href={href}
+                      target="_blank"
+                      rel="noreferrer noopener"
+                      className={externalLinkStyle}
+                      aria-label={`${label} (opens in a new tab)`}
+                    >
+                      {label}
+                      <ExternalLink />
+                    </a>
+                  </li>
+                ))}
+              </ul>
+            </nav>
+          </div>
         </div>
 
-        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 text-xs uppercase tracking-[0.2em] opacity-60">
-          <ul className="flex flex-wrap gap-x-5 gap-y-2">
-            {socialLinks.map(({ href, label }) => (
-              <li key={href}>
-                <a
-                  href={href}
-                  target="_blank"
-                  rel="noreferrer noopener"
-                  className="hover:opacity-100 transition-opacity"
-                >
-                  {label}
-                </a>
-              </li>
-            ))}
-          </ul>
-          <p>&copy; {new Date().getFullYear()} Daniel Bergholz</p>
-        </div>
+        <p className="text-xs text-foreground/50">
+          &copy; {new Date().getFullYear()} Daniel Bergholz
+        </p>
       </div>
     </footer>
   )

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -1,0 +1,83 @@
+import Link from "next/link"
+
+const footerLinks = [
+  { href: "/videos", label: "Videos" },
+  { href: "/courses", label: "Courses" },
+  { href: "/products", label: "Products" },
+  { href: "/work-with-me", label: "Work with me" },
+  { href: "/links", label: "Links" }
+]
+
+const socialLinks = [
+  {
+    href: "https://www.youtube.com/@DanielBergholz",
+    label: "YouTube"
+  },
+  {
+    href: "https://twitter.com/danielbergholz",
+    label: "X (Twitter)"
+  },
+  {
+    href: "https://www.linkedin.com/in/daniel-gobbi-bergholz/",
+    label: "LinkedIn"
+  },
+  {
+    href: "https://github.com/danielbergholz",
+    label: "GitHub"
+  }
+]
+
+export function Footer() {
+  return (
+    <footer className="mt-20 md:mt-28 pt-8 border-t border-current/10 dark:border-current/20">
+      <div className="max-w-5xl mx-auto flex flex-col gap-8 md:gap-10">
+        <div className="flex flex-col md:flex-row md:items-start md:justify-between gap-8">
+          <div className="flex flex-col gap-3">
+            <p className="font-bold text-sm uppercase tracking-[0.15em]">
+              Daniel Bergholz
+            </p>
+            <a
+              href="mailto:bergholz.daniel@gmail.com"
+              className="text-sm opacity-60 hover:opacity-100 transition-opacity w-max"
+            >
+              bergholz.daniel@gmail.com
+            </a>
+          </div>
+
+          <nav aria-label="Footer">
+            <ul className="flex flex-wrap gap-x-6 gap-y-2 text-xs uppercase tracking-[0.2em]">
+              {footerLinks.map(({ href, label }) => (
+                <li key={href}>
+                  <Link
+                    href={href}
+                    className="opacity-60 hover:opacity-100 transition-opacity"
+                  >
+                    {label}
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          </nav>
+        </div>
+
+        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 text-xs uppercase tracking-[0.2em] opacity-60">
+          <ul className="flex flex-wrap gap-x-5 gap-y-2">
+            {socialLinks.map(({ href, label }) => (
+              <li key={href}>
+                <a
+                  href={href}
+                  target="_blank"
+                  rel="noreferrer noopener"
+                  className="hover:opacity-100 transition-opacity"
+                >
+                  {label}
+                </a>
+              </li>
+            ))}
+          </ul>
+          <p>&copy; {new Date().getFullYear()} Daniel Bergholz</p>
+        </div>
+      </div>
+    </footer>
+  )
+}

--- a/src/components/icons.tsx
+++ b/src/components/icons.tsx
@@ -200,3 +200,26 @@ export function Read(props: React.SVGProps<SVGSVGElement>) {
     </svg>
   )
 }
+
+export function ExternalLink(props: React.SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="12"
+      height="12"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+      focusable="false"
+      {...props}
+    >
+      <path d="M15 3h6v6" />
+      <path d="M10 14 21 3" />
+      <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
+    </svg>
+  )
+}

--- a/src/components/nav.tsx
+++ b/src/components/nav.tsx
@@ -4,6 +4,8 @@ import Link from "next/link"
 import { usePathname } from "next/navigation"
 import { useCallback, useEffect, useId, useRef, useState } from "react"
 
+import { ExternalLink } from "@/components/icons"
+
 const navLinks = [
   { href: "/videos", label: "Videos", prefetch: true },
   { href: "/courses", label: "Courses", prefetch: true },
@@ -18,28 +20,6 @@ const internalLinkBase =
 
 const joinButtonStyle =
   "inline-flex items-center gap-1.5 text-xs uppercase tracking-[0.15em] text-violet-700 dark:text-violet-300 border border-violet-400/70 dark:border-violet-600/70 rounded-sm px-3 py-1.5 hover:bg-violet-50 dark:hover:bg-violet-950/40 hover:border-violet-500 dark:hover:border-violet-500 transition-colors"
-
-function ExternalIcon() {
-  return (
-    <svg
-      xmlns="http://www.w3.org/2000/svg"
-      width="12"
-      height="12"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth={2}
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      aria-hidden="true"
-      focusable="false"
-    >
-      <path d="M15 3h6v6" />
-      <path d="M10 14 21 3" />
-      <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
-    </svg>
-  )
-}
 
 export function Nav() {
   const pathname = usePathname()
@@ -97,7 +77,7 @@ export function Nav() {
       aria-label="Join on YouTube (opens in a new tab)"
     >
       YouTube Members
-      <ExternalIcon />
+      <ExternalLink />
     </a>
   )
 

--- a/src/components/nav.tsx
+++ b/src/components/nav.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link"
 import { usePathname } from "next/navigation"
-import { useState } from "react"
+import { useCallback, useEffect, useId, useRef, useState } from "react"
 
 const navLinks = [
   { href: "/videos", label: "Videos", prefetch: true },
@@ -19,14 +19,48 @@ const joinButtonStyle =
 export function Nav() {
   const pathname = usePathname()
   const [isMenuOpen, setIsMenuOpen] = useState(false)
+  const menuId = useId()
+  const menuRef = useRef<HTMLDivElement>(null)
+  const toggleRef = useRef<HTMLButtonElement>(null)
 
-  const activeStyle = (path: string) =>
-    pathname === path
-      ? ""
-      : "opacity-60 dark:opacity-70 hover:opacity-100 transition-opacity"
+  const isActive = (path: string) => pathname === path
 
-  const toggleMenu = () => setIsMenuOpen(!isMenuOpen)
-  const closeMenu = () => setIsMenuOpen(false)
+  const linkStyle = (path: string) => {
+    if (isActive(path)) {
+      return "font-bold underline underline-offset-4 decoration-current/40"
+    }
+    return "opacity-60 dark:opacity-70 hover:opacity-100 transition-opacity"
+  }
+
+  const closeMenu = useCallback(() => setIsMenuOpen(false), [])
+
+  const toggleMenu = () => setIsMenuOpen((open) => !open)
+
+  useEffect(() => {
+    if (!isMenuOpen) return
+
+    const previousOverflow = document.body.style.overflow
+    document.body.style.overflow = "hidden"
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        closeMenu()
+        toggleRef.current?.focus()
+      }
+    }
+
+    document.addEventListener("keydown", handleKeyDown)
+
+    const focusable = menuRef.current?.querySelectorAll<HTMLElement>(
+      'a[href], button:not([disabled]), [tabindex]:not([tabindex="-1"])'
+    )
+    focusable?.[0]?.focus()
+
+    return () => {
+      document.body.style.overflow = previousOverflow
+      document.removeEventListener("keydown", handleKeyDown)
+    }
+  }, [isMenuOpen, closeMenu])
 
   return (
     <nav className="relative pb-5 border-b border-current/10 dark:border-current/20">
@@ -35,6 +69,7 @@ export function Nav() {
           href="/"
           className="font-bold text-lg md:text-xl tracking-[0.15em]"
           onClick={closeMenu}
+          aria-current={pathname === "/" ? "page" : undefined}
         >
           BERGHOLZ
         </Link>
@@ -44,8 +79,9 @@ export function Nav() {
             <li key={href}>
               <Link
                 href={href}
-                className={activeStyle(href)}
+                className={linkStyle(href)}
                 prefetch={prefetch}
+                aria-current={isActive(href) ? "page" : undefined}
               >
                 {label}
               </Link>
@@ -64,18 +100,21 @@ export function Nav() {
         </ul>
 
         <button
+          ref={toggleRef}
           type="button"
           onClick={toggleMenu}
-          className="md:hidden flex flex-col justify-center items-center w-6 h-6 space-y-1.5 cursor-pointer"
-          aria-label="Toggle menu"
+          className="md:hidden flex flex-col justify-center items-center w-11 h-11 -mr-2 space-y-1.5 cursor-pointer"
+          aria-label={isMenuOpen ? "Close menu" : "Open menu"}
+          aria-expanded={isMenuOpen}
+          aria-controls={menuId}
         >
           <span
-            className={`block w-5 h-[1px] bg-current transition-all duration-300 ${
+            className={`block w-5 h-[1px] bg-current transition-all duration-300 motion-reduce:transition-none ${
               isMenuOpen ? "rotate-45 translate-y-[4px]" : ""
             }`}
           />
           <span
-            className={`block w-5 h-[1px] bg-current transition-all duration-300 ${
+            className={`block w-5 h-[1px] bg-current transition-all duration-300 motion-reduce:transition-none ${
               isMenuOpen ? "-rotate-45 -translate-y-[4px]" : ""
             }`}
           />
@@ -83,33 +122,50 @@ export function Nav() {
       </div>
 
       {isMenuOpen && (
-        <div className="md:hidden absolute top-full left-0 right-0 bg-white dark:bg-black border-b border-current/10 dark:border-current/20 py-6 z-50">
-          <ul className="flex flex-col space-y-4 text-xs uppercase tracking-[0.2em]">
-            {navLinks.map(({ href, label, prefetch }) => (
-              <li key={href}>
-                <Link
-                  href={href}
-                  className={`block ${activeStyle(href)}`}
+        <>
+          <button
+            type="button"
+            aria-label="Close menu"
+            className="md:hidden fixed inset-0 bg-black/40 dark:bg-black/60 z-40 cursor-default"
+            onClick={closeMenu}
+            tabIndex={-1}
+          />
+          <div
+            ref={menuRef}
+            id={menuId}
+            className="md:hidden fixed inset-x-0 top-[calc(3.5rem+env(safe-area-inset-top,0px))] bottom-0 bg-white dark:bg-black border-b border-current/10 dark:border-current/20 py-6 z-50 overflow-y-auto"
+            style={{
+              paddingBottom: "max(1.5rem, env(safe-area-inset-bottom))"
+            }}
+          >
+            <ul className="flex flex-col space-y-4 text-xs uppercase tracking-[0.2em] px-6 md:px-10">
+              {navLinks.map(({ href, label, prefetch }) => (
+                <li key={href}>
+                  <Link
+                    href={href}
+                    className={`block py-1 ${linkStyle(href)}`}
+                    onClick={closeMenu}
+                    prefetch={prefetch}
+                    aria-current={isActive(href) ? "page" : undefined}
+                  >
+                    {label}
+                  </Link>
+                </li>
+              ))}
+              <li>
+                <a
+                  href={JOIN_URL}
+                  target="_blank"
+                  rel="noreferrer noopener"
                   onClick={closeMenu}
-                  prefetch={prefetch}
+                  className={`inline-block ${joinButtonStyle}`}
                 >
-                  {label}
-                </Link>
+                  Join
+                </a>
               </li>
-            ))}
-            <li>
-              <a
-                href={JOIN_URL}
-                target="_blank"
-                rel="noreferrer noopener"
-                onClick={closeMenu}
-                className={joinButtonStyle}
-              >
-                Join
-              </a>
-            </li>
-          </ul>
-        </div>
+            </ul>
+          </div>
+        </>
       )}
     </nav>
   )

--- a/src/components/nav.tsx
+++ b/src/components/nav.tsx
@@ -13,8 +13,33 @@ const navLinks = [
 
 const JOIN_URL = "https://www.youtube.com/@DanielBergholz/join"
 
+const internalLinkBase =
+  "text-sm normal-case tracking-normal font-medium transition-colors"
+
 const joinButtonStyle =
-  "inline-block text-violet-600 dark:text-violet-400 border border-violet-400/60 dark:border-violet-700/60 rounded-sm px-3 py-1.5 hover:border-violet-500 dark:hover:border-violet-500 transition-colors"
+  "inline-flex items-center gap-1.5 text-xs uppercase tracking-[0.15em] text-violet-700 dark:text-violet-300 border border-violet-400/70 dark:border-violet-600/70 rounded-sm px-3 py-1.5 hover:bg-violet-50 dark:hover:bg-violet-950/40 hover:border-violet-500 dark:hover:border-violet-500 transition-colors"
+
+function ExternalIcon() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="12"
+      height="12"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+      focusable="false"
+    >
+      <path d="M15 3h6v6" />
+      <path d="M10 14 21 3" />
+      <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
+    </svg>
+  )
+}
 
 export function Nav() {
   const pathname = usePathname()
@@ -27,9 +52,9 @@ export function Nav() {
 
   const linkStyle = (path: string) => {
     if (isActive(path)) {
-      return "font-bold underline underline-offset-4 decoration-current/40"
+      return `${internalLinkBase} text-foreground underline underline-offset-4 decoration-current/50`
     }
-    return "opacity-60 dark:opacity-70 hover:opacity-100 transition-opacity"
+    return `${internalLinkBase} text-foreground/60 hover:text-foreground`
   }
 
   const closeMenu = useCallback(() => setIsMenuOpen(false), [])
@@ -62,42 +87,58 @@ export function Nav() {
     }
   }, [isMenuOpen, closeMenu])
 
+  const joinLink = (
+    <a
+      href={JOIN_URL}
+      target="_blank"
+      rel="noreferrer noopener"
+      onClick={closeMenu}
+      className={joinButtonStyle}
+      aria-label="Join on YouTube (opens in a new tab)"
+    >
+      YouTube Members
+      <ExternalIcon />
+    </a>
+  )
+
   return (
-    <nav className="relative pb-5 border-b border-current/10 dark:border-current/20">
-      <div className="flex justify-between items-center">
+    <nav
+      className="relative pb-5 border-b border-current/10 dark:border-current/20"
+      aria-label="Main"
+    >
+      <div className="flex justify-between items-center gap-4">
         <Link
           href="/"
-          className="font-bold text-lg md:text-xl tracking-[0.15em]"
+          className="font-bold text-lg md:text-xl tracking-[0.15em] shrink-0"
           onClick={closeMenu}
           aria-current={pathname === "/" ? "page" : undefined}
         >
           BERGHOLZ
         </Link>
 
-        <ul className="hidden md:flex items-center space-x-8 text-xs uppercase tracking-[0.2em]">
-          {navLinks.map(({ href, label, prefetch }) => (
-            <li key={href}>
-              <Link
-                href={href}
-                className={linkStyle(href)}
-                prefetch={prefetch}
-                aria-current={isActive(href) ? "page" : undefined}
-              >
-                {label}
-              </Link>
-            </li>
-          ))}
-          <li>
-            <a
-              href={JOIN_URL}
-              target="_blank"
-              rel="noreferrer noopener"
-              className={joinButtonStyle}
-            >
-              Join
-            </a>
-          </li>
-        </ul>
+        <div className="hidden md:flex items-center gap-6">
+          <ul className="flex items-center gap-6">
+            {navLinks.map(({ href, label, prefetch }) => (
+              <li key={href}>
+                <Link
+                  href={href}
+                  className={linkStyle(href)}
+                  prefetch={prefetch}
+                  aria-current={isActive(href) ? "page" : undefined}
+                >
+                  {label}
+                </Link>
+              </li>
+            ))}
+          </ul>
+
+          <div
+            className="h-5 w-px bg-current/15 dark:bg-current/25 shrink-0"
+            aria-hidden="true"
+          />
+
+          {joinLink}
+        </div>
 
         <button
           ref={toggleRef}
@@ -138,32 +179,35 @@ export function Nav() {
               paddingBottom: "max(1.5rem, env(safe-area-inset-bottom))"
             }}
           >
-            <ul className="flex flex-col space-y-4 text-xs uppercase tracking-[0.2em] px-6 md:px-10">
-              {navLinks.map(({ href, label, prefetch }) => (
-                <li key={href}>
-                  <Link
-                    href={href}
-                    className={`block py-1 ${linkStyle(href)}`}
-                    onClick={closeMenu}
-                    prefetch={prefetch}
-                    aria-current={isActive(href) ? "page" : undefined}
-                  >
-                    {label}
-                  </Link>
-                </li>
-              ))}
-              <li>
-                <a
-                  href={JOIN_URL}
-                  target="_blank"
-                  rel="noreferrer noopener"
-                  onClick={closeMenu}
-                  className={`inline-block ${joinButtonStyle}`}
-                >
-                  Join
-                </a>
-              </li>
-            </ul>
+            <div className="flex flex-col gap-6 px-6 md:px-10">
+              <div>
+                <p className="mb-3 text-[10px] uppercase tracking-[0.2em] text-foreground/50">
+                  Pages
+                </p>
+                <ul className="flex flex-col gap-3">
+                  {navLinks.map(({ href, label, prefetch }) => (
+                    <li key={href}>
+                      <Link
+                        href={href}
+                        className={`block py-1 ${linkStyle(href)}`}
+                        onClick={closeMenu}
+                        prefetch={prefetch}
+                        aria-current={isActive(href) ? "page" : undefined}
+                      >
+                        {label}
+                      </Link>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+
+              <div className="border-t border-current/10 dark:border-current/20 pt-6">
+                <p className="mb-3 text-[10px] uppercase tracking-[0.2em] text-foreground/50">
+                  YouTube
+                </p>
+                {joinLink}
+              </div>
+            </div>
           </div>
         </>
       )}

--- a/src/components/skeletons.tsx
+++ b/src/components/skeletons.tsx
@@ -1,0 +1,158 @@
+function Pulse({ className }: { className: string }) {
+  return (
+    <div
+      className={`animate-pulse rounded-lg bg-current/10 dark:bg-current/15 ${className}`}
+      aria-hidden="true"
+    />
+  )
+}
+
+const skeletonKeys = {
+  four: ["social-1", "social-2", "social-3", "social-4"],
+  three: ["card-1", "card-2", "card-3"],
+  two: ["row-1", "row-2"]
+} as const
+
+export function ContentCardSkeleton({
+  featured = false
+}: {
+  featured?: boolean
+}) {
+  if (featured) {
+    return (
+      <div
+        className="flex flex-col md:flex-row gap-5 md:gap-6 p-5 md:p-6 rounded-lg border border-current/10 dark:border-current/20"
+        aria-hidden="true"
+      >
+        <Pulse className="aspect-video w-full md:w-[440px] md:shrink-0" />
+        <div className="flex flex-1 flex-col gap-3">
+          <Pulse className="h-7 w-3/4" />
+          <Pulse className="h-4 w-full" />
+          <Pulse className="h-4 w-5/6" />
+          <Pulse className="h-3 w-1/3 mt-2" />
+          <div className="flex gap-3 mt-2">
+            <Pulse className="h-9 w-24" />
+            <Pulse className="h-9 w-20" />
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div
+      className="flex flex-col gap-3 p-4 rounded-lg border border-current/10 dark:border-current/20"
+      aria-hidden="true"
+    >
+      <Pulse className="aspect-video w-full" />
+      <Pulse className="h-5 w-full" />
+      <Pulse className="h-5 w-2/3" />
+      <div className="flex justify-between">
+        <Pulse className="h-3 w-20" />
+        <Pulse className="h-7 w-16" />
+      </div>
+    </div>
+  )
+}
+
+export function HomeLoadingSkeleton() {
+  return (
+    <div className="my-14 md:my-28 max-w-4xl mx-auto flex flex-col gap-14 md:gap-20">
+      <div
+        className="w-auto md:w-[560px] mx-auto flex flex-col gap-5"
+        aria-hidden="true"
+      >
+        <Pulse className="h-12 w-32" />
+        <Pulse className="h-6 w-full" />
+        <Pulse className="h-6 w-4/5" />
+        <Pulse className="h-4 w-28 mt-2" />
+        <div className="flex gap-4 mt-4">
+          {skeletonKeys.four.map((key) => (
+            <Pulse key={key} className="h-6 w-6 rounded-full" />
+          ))}
+        </div>
+        <div className="flex gap-12 py-6">
+          <Pulse className="h-10 w-24" />
+          <Pulse className="h-10 w-24" />
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-6">
+        <div className="flex justify-between items-end">
+          <Pulse className="h-8 w-40" />
+          <Pulse className="h-4 w-20" />
+        </div>
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+          {skeletonKeys.three.map((key) => (
+            <ContentCardSkeleton key={key} />
+          ))}
+        </div>
+      </div>
+
+      <Pulse className="h-32 w-full rounded-lg" />
+    </div>
+  )
+}
+
+export function VideosLoadingSkeleton() {
+  return (
+    <div className="my-14 md:my-28 max-w-5xl mx-auto flex flex-col gap-5">
+      <div aria-hidden="true">
+        <Pulse className="h-10 w-32 mb-4" />
+        <Pulse className="h-4 w-full max-w-2xl mb-2" />
+        <Pulse className="h-4 w-3/4 max-w-xl mb-6" />
+        <Pulse className="h-11 w-full rounded-lg mb-5" />
+      </div>
+      <div className="flex flex-col gap-4">
+        {skeletonKeys.two.map((key) => (
+          <ContentCardSkeleton key={key} featured />
+        ))}
+      </div>
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+        {skeletonKeys.three.map((key) => (
+          <ContentCardSkeleton key={key} />
+        ))}
+      </div>
+    </div>
+  )
+}
+
+export function CoursesLoadingSkeleton() {
+  return (
+    <div className="my-14 md:my-28 max-w-[978px] mx-auto flex flex-col gap-6">
+      <div aria-hidden="true">
+        <Pulse className="h-10 w-36 mb-4" />
+        <Pulse className="h-4 w-full max-w-2xl mb-2" />
+        <Pulse className="h-4 w-2/3 max-w-xl mb-6" />
+      </div>
+      <div className="flex flex-col gap-4">
+        {skeletonKeys.two.map((key) => (
+          <Pulse key={key} className="h-48 w-full rounded-lg" />
+        ))}
+      </div>
+      <div className="flex flex-wrap gap-4">
+        {skeletonKeys.three.map((key) => (
+          <Pulse key={key} className="h-56 w-[270px] rounded-lg" />
+        ))}
+      </div>
+    </div>
+  )
+}
+
+export function ContentFeedSkeleton() {
+  return (
+    <div className="flex flex-col gap-5" aria-hidden="true">
+      <Pulse className="h-11 w-full rounded-lg" />
+      <div className="flex flex-col gap-4">
+        {skeletonKeys.two.map((key) => (
+          <ContentCardSkeleton key={key} featured />
+        ))}
+      </div>
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+        {skeletonKeys.three.map((key) => (
+          <ContentCardSkeleton key={key} />
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/components/video.tsx
+++ b/src/components/video.tsx
@@ -32,14 +32,14 @@ export function Video({
       target="_blank"
       href={`https://www.youtube.com/playlist?list=${video.id}`}
       title={title}
-      className="group border border-current/10 dark:border-current/20 rounded-lg p-5 md:p-6 flex flex-col md:flex-row items-center gap-4 hover:border-current/30 dark:hover:border-current/40 transition-all duration-300 max-w-[306px] sm:max-w-full"
+      className="group border border-current/10 dark:border-current/20 rounded-lg p-5 md:p-6 flex flex-col md:flex-row items-center gap-4 hover:border-current/30 dark:hover:border-current/40 transition-all duration-300 motion-reduce:transition-none max-w-[306px] sm:max-w-full"
     >
       <div className="flex flex-col justify-between h-full order-2 md:order-1 gap-2 sm:gap-4">
         <div className="flex items-center justify-between md:justify-normal md:gap-3">
           <h2 className="font-bold text-lg md:text-xl group-hover:opacity-80 transition-opacity">
             {title}
           </h2>
-          <span className="text-xs uppercase tracking-widest opacity-40 border border-current/20 dark:border-current/30 rounded-sm px-2 py-0.5 shrink-0">
+          <span className="text-xs uppercase tracking-widest opacity-60 border border-current/20 dark:border-current/30 rounded-sm px-2 py-0.5 shrink-0">
             {locale === "pt" ? "PT-BR" : "EN"}
           </span>
         </div>
@@ -59,7 +59,7 @@ export function Video({
               </span>
             )}
           </p>
-          <p className="opacity-40 text-xs md:text-sm tracking-wide">
+          <p className="opacity-60 text-xs md:text-sm tracking-wide">
             {itemCount} videos
           </p>
         </div>
@@ -78,7 +78,7 @@ export function Video({
       target="_blank"
       href={`https://www.youtube.com/playlist?list=${video.id}`}
       title={title}
-      className="group border border-current/10 dark:border-current/20 rounded-lg p-4 flex flex-col items-center gap-4 hover:border-current/30 dark:hover:border-current/40 transition-all duration-300"
+      className="group border border-current/10 dark:border-current/20 rounded-lg p-4 flex flex-col items-center gap-4 hover:border-current/30 dark:hover:border-current/40 transition-all duration-300 motion-reduce:transition-none"
     >
       <Image
         src={thumbnail.url}
@@ -89,10 +89,10 @@ export function Video({
       />
       <div className="flex flex-col gap-2 w-full">
         <div className="flex justify-between items-center">
-          <h2 className="font-bold text-lg w-[216px] group-hover:opacity-80 transition-opacity">
+          <h2 className="font-bold text-lg min-w-0 flex-1 group-hover:opacity-80 transition-opacity">
             {title}
           </h2>
-          <span className="text-xs uppercase tracking-widest opacity-40 border border-current/20 dark:border-current/30 rounded-sm px-2 py-0.5 shrink-0">
+          <span className="text-xs uppercase tracking-widest opacity-60 border border-current/20 dark:border-current/30 rounded-sm px-2 py-0.5 shrink-0">
             {locale === "pt" ? "PT-BR" : "EN"}
           </span>
         </div>
@@ -100,7 +100,7 @@ export function Video({
           <span className="text-xs uppercase tracking-widest text-emerald-600 dark:text-emerald-400 border border-emerald-300 dark:border-emerald-800 rounded-sm px-2 py-0.5">
             Free
           </span>
-          <p className="opacity-40 text-xs tracking-wide">
+          <p className="opacity-60 text-xs tracking-wide">
             {itemCount} {itemCount === 1 ? "video" : "videos"}
           </p>
         </div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Ships the full UX improvement pass discussed in the site audit: better feedback during loading/errors, stronger accessibility, clearer navigation, and page closure via a footer.

## Changes

### Global
- Global `focus-visible` outlines, `prefers-reduced-motion` support, and skip-to-content link
- Site-wide footer with email, nav links, social links, and `/links`
- Dynamic `manifest.ts` plus light/dark `theme-color` meta tags
- `id="main"` on all page landmarks for skip-link targeting

### Navigation
- Active nav links use `aria-current="page"` and a bold underline
- Mobile menu: backdrop overlay, body scroll lock, Escape to close, `aria-expanded` / `aria-controls`, larger tap target
- **Nav hierarchy:** internal pages use sentence-case text links; YouTube membership is separated by a divider, labeled "YouTube Members" with an external-link icon; mobile menu groups items under "Pages" and "YouTube"

### Loading & errors
- Route-level loading skeletons for `/`, `/videos`, and `/courses`
- App-level `error.tsx` with retry + home link
- `ContentFeed` Suspense fallback uses matching skeletons

### Content & pages
- Search: clear button, visible result count, `aria-live` announcements
- Courses: intro copy, EN/PT section headings, empty states
- Home: empty state for latest videos, `priority` on first thumbnail, social link `aria-label`s, fixed `mailto:` link
- Contrast pass: `opacity-40` → `opacity-60` on secondary text
- Larger mobile touch targets on Watch/Read actions
- Course card titles use flexible width instead of fixed `216px`

## Verification

- `npm run format`
- `npm run check` (lint + typecheck)
- `npm test` (14/14 passing)
- `npm run build` (production build succeeds)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f38c5-e425-7ea0-bc07-da9bcb784065"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f38c5-e425-7ea0-bc07-da9bcb784065"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

