### PR TITLE
Show a language badge on video cards when it differs from the locale

### DIFF
--- a/src/components/content-card.tsx
+++ b/src/components/content-card.tsx
@@ -14,12 +14,14 @@ function Thumbnail({
   item,
   featured,
   priority = false,
-  t
+  t,
+  languageBadge
 }: {
   item: ContentItem
   featured: boolean
   priority?: boolean
   t: CardLabels
+  languageBadge?: string
 }) {
   const { title, thumbnailUrl, videoUrl, articleUrl, durationSeconds } = item
   const isArticleOnly = !videoUrl && !!articleUrl
@@ -41,6 +43,11 @@ function Thumbnail({
       {isArticleOnly && (
         <span className="absolute left-2 top-2 rounded-sm border border-current/20 bg-background px-1.5 py-0.5 text-[10px] uppercase tracking-widest opacity-70">
           {t.article}
+        </span>
+      )}
+      {languageBadge && (
+        <span className="absolute left-2 top-2 rounded-sm border border-current/20 bg-background px-1.5 py-0.5 text-[10px] uppercase tracking-widest opacity-70">
+          {languageBadge}
         </span>
       )}
       {videoUrl && (
@@ -155,6 +162,15 @@ export function ContentCard({
   const primary = videoUrl ?? articleUrl
   if (!primary) return null
 
+  // Badge only when the video's language differs from the UI locale — a feed
+  // that matches the reader's language stays unlabeled.
+  const languageBadge =
+    item.language && item.language !== locale
+      ? item.language === "pt"
+        ? "PT-BR"
+        : "EN"
+      : undefined
+
   if (featured) {
     return (
       <article
@@ -167,7 +183,13 @@ export function ContentCard({
           title={title}
           className="block md:w-[440px] md:shrink-0"
         >
-          <Thumbnail item={item} featured priority={priority} t={t} />
+          <Thumbnail
+            item={item}
+            featured
+            priority={priority}
+            t={t}
+            languageBadge={languageBadge}
+          />
         </a>
         <div className="flex flex-1 flex-col gap-3">
           <a
@@ -210,7 +232,13 @@ export function ContentCard({
         title={title}
         className="flex flex-col gap-3"
       >
-        <Thumbnail item={item} featured={false} priority={priority} t={t} />
+        <Thumbnail
+          item={item}
+          featured={false}
+          priority={priority}
+          t={t}
+          languageBadge={languageBadge}
+        />
         <h2 className="font-bold text-base md:text-lg leading-snug line-clamp-2 group-hover:opacity-80 transition-opacity">
           {title}
         </h2>

--- a/src/data-access/content.ts
+++ b/src/data-access/content.ts
@@ -2,7 +2,7 @@ import { getArticles } from "@/data-access/blog"
 import {
   getCourseVideoIds,
   getLatestVideos,
-  getVideoDurations
+  getVideoDetails
 } from "@/data-access/youtube"
 import { buildContentFeed } from "@/lib/feed"
 import type { ContentItem } from "@/lib/types"
@@ -18,9 +18,9 @@ export const getContentFeed = async (): Promise<ContentItem[]> => {
     getCourseVideoIds()
   ])
 
-  const durations = await getVideoDurations(
+  const details = await getVideoDetails(
     videos.map((video) => video.snippet.resourceId.videoId)
   )
 
-  return buildContentFeed(videos, articles, courseVideoIds, durations)
+  return buildContentFeed(videos, articles, courseVideoIds, details)
 }

--- a/src/data-access/youtube.ts
+++ b/src/data-access/youtube.ts
@@ -1,4 +1,9 @@
-import type { ChannelStats, LatestVideos, Playlists } from "@/lib/types"
+import type {
+  ChannelStats,
+  LatestVideos,
+  Playlists,
+  VideoDetails
+} from "@/lib/types"
 import { parseIsoDuration } from "@/lib/utils"
 
 const API_KEY = process.env.YOUTUBE_API_KEY
@@ -79,8 +84,12 @@ export const getCourses = async () => {
   return { englishCourses, portugueseCourses }
 }
 
-type DurationResponse = {
-  items?: { id: string; contentDetails?: { duration?: string } }[]
+type VideoDetailsResponse = {
+  items?: {
+    id: string
+    contentDetails?: { duration?: string }
+    snippet?: { defaultAudioLanguage?: string; defaultLanguage?: string }
+  }[]
 }
 
 type PlaylistVideoIdResponse = {
@@ -88,31 +97,36 @@ type PlaylistVideoIdResponse = {
   nextPageToken?: string
 }
 
-// Durations live on the videos endpoint, not playlistItems. Used to show video
-// length and to detect Shorts (which the API has no flag for). Batched 50 ids
-// per call; durations never change, so cache for a day.
-export const getVideoDurations = async (videoIds: string[]) => {
-  const durations = new Map<string, number>()
+// Durations and language live on the videos endpoint, not playlistItems.
+// Durations show video length and detect Shorts (which the API has no flag
+// for); language drives the card badge. Batched 50 ids per call — extra
+// `part`s cost no additional quota. Neither changes after upload, so cache
+// for a day.
+export const getVideoDetails = async (videoIds: string[]) => {
+  const details = new Map<string, VideoDetails>()
   for (let i = 0; i < videoIds.length; i += 50) {
     const batch = videoIds.slice(i, i + 50)
-    const url = `${BASE_URL}/videos?part=contentDetails&id=${batch.join(",")}&key=${API_KEY}`
+    const url = `${BASE_URL}/videos?part=contentDetails,snippet&id=${batch.join(",")}&key=${API_KEY}`
     const response = await fetch(url, { next: { revalidate: 86400 } })
     if (!response.ok) {
       throw new Error(`YouTube API error: ${response.status}`)
     }
 
-    const data: DurationResponse = await response.json()
+    const data: VideoDetailsResponse = await response.json()
     if (!Array.isArray(data.items)) {
       throw new Error("YouTube API: missing video items")
     }
 
     for (const item of data.items) {
-      if (item.contentDetails?.duration) {
-        durations.set(item.id, parseIsoDuration(item.contentDetails.duration))
-      }
+      const duration = item.contentDetails?.duration
+      details.set(item.id, {
+        durationSeconds: duration ? parseIsoDuration(duration) : undefined,
+        language:
+          item.snippet?.defaultAudioLanguage ?? item.snippet?.defaultLanguage
+      })
     }
   }
-  return durations
+  return details
 }
 
 const getPlaylistVideoIds = async (playlistId: string): Promise<string[]> => {

--- a/src/lib/feed.test.ts
+++ b/src/lib/feed.test.ts
@@ -4,9 +4,10 @@ import {
   articleSlugFromDescription,
   buildContentFeed,
   firstMeaningfulLine,
+  siteLanguage,
   videoIdFromBody
 } from "./feed.ts"
-import type { Article, LatestVideo } from "./types"
+import type { Article, LatestVideo, VideoDetails } from "./types"
 
 // --- fixtures ---
 const thumb = (url: string) => ({ url, width: 1280, height: 720 })
@@ -57,7 +58,9 @@ function article(opts: {
 }
 
 const noCourses = new Set<string>()
-const durations = (entries: [string, number][]) => new Map(entries)
+const details = (entries: [string, VideoDetails][]) => new Map(entries)
+const durations = (entries: [string, number][]) =>
+  details(entries.map(([id, s]) => [id, { durationSeconds: s }]))
 
 // --- helpers ---
 test("videoIdFromBody handles every link format", () => {
@@ -96,6 +99,15 @@ test("firstMeaningfulLine skips promo lines", () => {
     undefined
   )
   assert.equal(firstMeaningfulLine(""), undefined)
+})
+
+test("siteLanguage collapses BCP-47 tags to the site's languages", () => {
+  assert.equal(siteLanguage("en"), "en")
+  assert.equal(siteLanguage("en-US"), "en")
+  assert.equal(siteLanguage("pt-BR"), "pt")
+  assert.equal(siteLanguage("pt-PT"), "pt")
+  assert.equal(siteLanguage("es"), undefined)
+  assert.equal(siteLanguage(undefined), undefined)
 })
 
 // --- buildContentFeed ---
@@ -217,6 +229,26 @@ test("an article linking an out-of-window video still offers Watch", () => {
   assert.equal(feed.length, 1)
   assert.equal(feed[0].videoUrl, "https://www.youtube.com/watch?v=oldvideo111")
   assert.equal(feed[0].articleUrl, "https://dev.to/danielbergholz/old")
+})
+
+test("video language flows into the item; article-only cards have none", () => {
+  const pt = video({ id: "ptvideo0001" })
+  const unset = video({ id: "unsetvid001" })
+  const a = article({ id: 11, slug: "text-only", body: "" })
+  const feed = buildContentFeed(
+    [pt, unset],
+    [a],
+    noCourses,
+    details([
+      ["ptvideo0001", { durationSeconds: 600, language: "pt-BR" }],
+      ["unsetvid001", { durationSeconds: 600 }]
+    ])
+  )
+
+  const byId = new Map(feed.map((i) => [i.id, i]))
+  assert.equal(byId.get("ptvideo0001")?.language, "pt")
+  assert.equal(byId.get("unsetvid001")?.language, undefined)
+  assert.equal(byId.get("article-11")?.language, undefined)
 })
 
 test("sorts newest first across videos and articles", () => {

--- a/src/lib/feed.ts
+++ b/src/lib/feed.ts
@@ -1,4 +1,9 @@
-import type { Article, ContentItem, LatestVideo } from "@/lib/types"
+import type {
+  Article,
+  ContentItem,
+  LatestVideo,
+  VideoDetails
+} from "@/lib/types"
 
 // Videos at or under this length are treated as Shorts and dropped from the feed.
 // The API has no Shorts flag; this channel's Shorts are all <=65s and its shortest
@@ -41,10 +46,17 @@ export function firstMeaningfulLine(text: string): string | undefined {
   return undefined
 }
 
+// Collapse YouTube's BCP-47 tag ("en", "en-US", "pt-BR") to the site's two
+// languages; anything else (or unset) is unknown and gets no badge.
+export function siteLanguage(tag: string | undefined): "en" | "pt" | undefined {
+  const primary = tag?.split("-")[0].toLowerCase()
+  return primary === "en" || primary === "pt" ? primary : undefined
+}
+
 function videoToItem(
   video: LatestVideo,
   article: Article | undefined,
-  durationSeconds: number | undefined
+  details: VideoDetails | undefined
 ): ContentItem {
   const { title, publishedAt, thumbnails, resourceId, description } =
     video.snippet
@@ -57,7 +69,8 @@ function videoToItem(
     thumbnailUrl: thumbnail.url,
     // Prefer the article's clean excerpt; fall back to the video's first real line.
     description: article?.description ?? firstMeaningfulLine(description ?? ""),
-    durationSeconds,
+    durationSeconds: details?.durationSeconds,
+    language: siteLanguage(details?.language),
     videoUrl: `https://www.youtube.com/watch?v=${resourceId.videoId}`,
     articleUrl: article?.url,
     readingMinutes: article?.reading_time_minutes
@@ -89,7 +102,7 @@ export function buildContentFeed(
   videos: LatestVideo[],
   articles: Article[],
   courseVideoIds: Set<string>,
-  durations: Map<string, number>
+  details: Map<string, VideoDetails>
 ): ContentItem[] {
   const articleByVideoId = new Map<string, Article>()
   const articleBySlug = new Map<string, Article>()
@@ -108,7 +121,8 @@ export function buildContentFeed(
     // Drop course videos (they have their own page) and Shorts (by duration —
     // keep anything whose duration is unknown rather than guess).
     if (courseVideoIds.has(videoId)) continue
-    const duration = durations.get(videoId)
+    const videoDetails = details.get(videoId)
+    const duration = videoDetails?.durationSeconds
     if (duration !== undefined && duration <= SHORTS_MAX_SECONDS) continue
 
     let article = articleByVideoId.get(videoId)
@@ -117,7 +131,7 @@ export function buildContentFeed(
       if (slug) article = articleBySlug.get(slug)
     }
     if (article) usedArticleIds.add(article.id)
-    items.push(videoToItem(video, article, duration))
+    items.push(videoToItem(video, article, videoDetails))
   }
 
   // Posts with no matching video card become their own cards (still linking a

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -24,9 +24,19 @@ export type ContentItem = {
   thumbnailUrl: string
   description?: string
   durationSeconds?: number
+  // Spoken language of the video (from YouTube metadata); absent for
+  // article-only items and videos whose language isn't set.
+  language?: "en" | "pt"
   videoUrl?: string
   articleUrl?: string
   readingMinutes?: number
+}
+
+// Per-video metadata from the videos endpoint, keyed by video id.
+// `language` is the raw BCP-47 tag YouTube reports (e.g. "en", "pt-BR").
+export type VideoDetails = {
+  durationSeconds?: number
+  language?: string
 }
 
 export type ChannelStats = {


### PR DESCRIPTION
## What

Video/article feed cards now show a PT-BR/EN badge on the thumbnail — but only when the video's spoken language differs from the page locale. A feed that matches the reader's language stays unlabeled.

## Why

The feed never filtered by language; it only looked all-English because the last 50 uploads are. A pt-BR upload would surface on both locales with no hint of its language. Course cards already carry a language badge; this brings the same signal to the feed without adding noise to the (currently all-English) `/en` page.

## How

- `getVideoDurations` → `getVideoDetails`: the existing `videos` API call now requests `contentDetails,snippet` (extra parts cost no additional quota) and returns duration plus the raw language tag (`defaultAudioLanguage` ?? `defaultLanguage`). Verified against the channel: the tag is set consistently (`en` / `pt-BR`) on both English and Portuguese uploads.
- New pure `siteLanguage()` helper in `feed.ts` collapses BCP-47 tags (`en-US`, `pt-BR`) to the site's two languages; unknown or unset tags yield no badge.
- `ContentItem.language` threads through `buildContentFeed`; `ContentCard` renders the badge top-left on the thumbnail (same styling as the "Article" tag, which never co-occurs with it).
- Article-only cards have no language (dev.to gives no signal) and stay unbadged.

## Reviewer notes

- Behavior today: pt-BR pages show "EN" on every video card (27 of 28 — the exception is an article card linking an out-of-window video, which has no metadata); `/en` shows zero badges. Verified in the browser on both locales.
- `npm run format`, `npm run check`, `npm test` (25/25, including two new tests for tag normalization and language flow), and `npm run build` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive UI and feed metadata from existing YouTube calls; no auth, filtering, or quota increase beyond extra response fields on the same endpoint.
> 
> **Overview**
> Feed video cards can now show a **PT-BR** or **EN** label on the thumbnail when YouTube’s spoken-language metadata doesn’t match the page locale; cards in the reader’s language stay unlabeled.
> 
> **Data pipeline:** `getVideoDurations` is replaced by `getVideoDetails`, which still batches the same `videos` API calls but requests `snippet` alongside `contentDetails` to read `defaultAudioLanguage` / `defaultLanguage`. `buildContentFeed` now takes a `VideoDetails` map and sets `ContentItem.language` via a new `siteLanguage()` helper that maps BCP-47 tags to `en` or `pt`. Article-only cards keep no language field.
> 
> **UI:** `ContentCard` compares `item.language` to `locale` and passes a badge into `Thumbnail`, using the same styling as the existing “Article” tag (top-left; mutually exclusive with article-only).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c23549c2feb55171aee1785f71ea180a1f12b6e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->