### PR TITLE
Reposition services around consulting, mentorship, and content

### DIFF
--- a/src/app/[lang]/courses/page.tsx
+++ b/src/app/[lang]/courses/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next"
 import { notFound } from "next/navigation"
 
+import { MembershipCTA } from "@/components/membership-cta"
 import { Video } from "@/components/video"
 import { getDictionary } from "@/dictionaries"
 import { getCourses } from "@/data-access/youtube"
@@ -156,6 +157,10 @@ export default async function Courses({
           )}
         </section>
       ))}
+
+      <div className="mt-10 md:mt-14">
+        <MembershipCTA t={dict.membership} />
+      </div>
     </main>
   )
 }

--- a/src/app/[lang]/links/page.tsx
+++ b/src/app/[lang]/links/page.tsx
@@ -1,14 +1,7 @@
 import type { Metadata } from "next"
 import { notFound } from "next/navigation"
 
-import {
-  DevTo,
-  Diamond,
-  GitHub,
-  LinkedIn,
-  Twitter,
-  YouTube
-} from "@/components/icons"
+import { DevTo, GitHub, LinkedIn, Twitter, YouTube } from "@/components/icons"
 import { Link } from "@/components/link"
 import { getDictionary } from "@/dictionaries"
 import { defaultLocale, hasLocale, pageAlternates } from "@/lib/i18n"
@@ -51,13 +44,6 @@ export default async function Links({
         aria-label={t.sectionAria}
         className="flex flex-col items-center gap-3"
       >
-        <Link
-          title={t.premium}
-          href="https://www.youtube.com/@DanielBergholz/join"
-        >
-          <Diamond width={28} height={28} />
-        </Link>
-
         <Link href="https://www.youtube.com/@DanielBergholz" title="YouTube">
           <YouTube width={28} height={28} />
         </Link>

--- a/src/app/[lang]/page.tsx
+++ b/src/app/[lang]/page.tsx
@@ -1,6 +1,5 @@
 import { ContentCard } from "@/components/content-card"
 import { GitHub, LinkedIn, Twitter, YouTube } from "@/components/icons"
-import { MembershipCTA } from "@/components/membership-cta"
 import { getDictionary } from "@/dictionaries"
 import { getContentFeed } from "@/data-access/content"
 import { getChannelStats } from "@/data-access/youtube"
@@ -174,10 +173,6 @@ async function HomeContent({ lang }: { lang: Locale }) {
             ))}
           </div>
         )}
-      </section>
-
-      <section aria-label={t.membershipAria}>
-        <MembershipCTA t={dict.membership} />
       </section>
     </main>
   )

--- a/src/app/[lang]/work-with-me/page.tsx
+++ b/src/app/[lang]/work-with-me/page.tsx
@@ -66,8 +66,12 @@ const stack = [
   "TypeScript",
   "Next.js",
   "PostgreSQL",
+  "SQLite",
   "GraphQL",
-  "Claude Code"
+  "Claude Code",
+  "Cursor",
+  "opencode",
+  "OpenAI"
 ]
 
 const comingSoonBadgeStyle =

--- a/src/app/[lang]/work-with-me/page.tsx
+++ b/src/app/[lang]/work-with-me/page.tsx
@@ -21,16 +21,16 @@ export async function generateMetadata({
     alternates: pageAlternates(locale, "/work-with-me"),
     keywords: [
       "Daniel Bergholz",
-      "Hire Developer",
-      "Fullstack Developer",
-      "Elixir Developer",
-      "Phoenix Developer",
-      "React Developer",
-      "Freelance Developer",
-      "Contractor",
+      "Business Consulting",
+      "AI Consulting",
+      "Technical Training",
+      "Workshops",
+      "AI Automation",
+      "1-on-1 Mentorship",
+      "Developer Mentorship",
+      "AI Adoption",
+      "Remote Work Abroad",
       "Content Creator",
-      "Startup Developer",
-      "AI Development",
       "Claude Code"
     ]
   }
@@ -70,8 +70,8 @@ const stack = [
   "Claude Code"
 ]
 
-const availableBadgeStyle =
-  "text-emerald-600 dark:text-emerald-400 border-emerald-300 dark:border-emerald-800"
+const comingSoonBadgeStyle =
+  "text-amber-600 dark:text-amber-400 border-amber-300 dark:border-amber-800"
 const openBadgeStyle =
   "text-violet-600 dark:text-violet-400 border-violet-300 dark:border-violet-800"
 
@@ -89,14 +89,14 @@ export default async function WorkWithMe({
 
   const services = [
     {
-      ...t.services.startup,
-      badge: t.available,
-      badgeColor: availableBadgeStyle
+      ...t.services.business,
+      badge: t.comingSoon,
+      badgeColor: comingSoonBadgeStyle
     },
     {
-      ...t.services.contract,
-      badge: t.available,
-      badgeColor: availableBadgeStyle
+      ...t.services.mentorship,
+      badge: t.comingSoon,
+      badgeColor: comingSoonBadgeStyle
     },
     {
       ...t.services.content,
@@ -108,6 +108,8 @@ export default async function WorkWithMe({
       badgeColor: openBadgeStyle
     }
   ]
+
+  const aiTooling = [t.ai.engineering, t.ai.automation, t.ai.agents]
 
   return (
     <main id="main" className="w-auto md:max-w-3xl mx-auto my-14 md:my-28">
@@ -178,10 +180,24 @@ export default async function WorkWithMe({
 
       <section className="mt-10 md:mt-14">
         <h2 className="font-serif text-2xl md:text-3xl italic tracking-tight mb-4">
-          {t.stackHeading}
+          {t.aiHeading}
         </h2>
         <hr className="w-12 border-t border-current opacity-20 mb-6" />
 
+        <div className="space-y-4">
+          {aiTooling.map((item) => (
+            <div key={item.title} className="flex flex-col gap-0.5">
+              <span className="text-sm md:text-base font-bold">
+                {item.title}
+              </span>
+              <span className="text-sm opacity-60">{item.description}</span>
+            </div>
+          ))}
+        </div>
+
+        <p className="mt-8 mb-3 text-[10px] uppercase tracking-[0.2em] opacity-50">
+          {t.stackHeading}
+        </p>
         <div className="flex flex-wrap gap-2">
           {stack.map((tech) => (
             <span

--- a/src/components/nav.tsx
+++ b/src/components/nav.tsx
@@ -4,7 +4,6 @@ import Link from "next/link"
 import { usePathname, useRouter } from "next/navigation"
 import { useCallback, useEffect, useId, useRef, useState } from "react"
 
-import { ExternalLink } from "@/components/icons"
 import type { Dictionary } from "@/dictionaries"
 import {
   type Locale,
@@ -13,8 +12,6 @@ import {
   locales,
   stripLocalePrefix
 } from "@/lib/i18n"
-
-const JOIN_URL = "https://www.youtube.com/@DanielBergholz/join"
 
 // Label for switching TO a locale, written in that locale's own language (the
 // W3C pattern for language switchers — the reader who needs it may not speak
@@ -28,9 +25,6 @@ const switchLocaleLabels: Record<Locale, string> = {
 
 const internalLinkBase =
   "text-sm normal-case tracking-normal font-medium transition-colors"
-
-const joinButtonStyle =
-  "inline-flex items-center gap-1.5 text-xs uppercase tracking-[0.15em] text-violet-700 dark:text-violet-300 border border-violet-400/70 dark:border-violet-600/70 rounded-sm px-3 py-1.5 hover:bg-violet-50 dark:hover:bg-violet-950/40 hover:border-violet-500 dark:hover:border-violet-500 transition-colors"
 
 type Props = {
   locale: Locale
@@ -92,20 +86,6 @@ export function Nav({ locale, t }: Props) {
       document.removeEventListener("keydown", handleKeyDown)
     }
   }, [isMenuOpen, closeMenu])
-
-  const joinLink = (
-    <a
-      href={JOIN_URL}
-      target="_blank"
-      rel="noreferrer noopener"
-      onClick={closeMenu}
-      className={joinButtonStyle}
-      aria-label={t.membersAria}
-    >
-      {t.members}
-      <ExternalLink />
-    </a>
-  )
 
   // Same page in the other locale: strip the current prefix, apply the target's.
   const basePath = stripLocalePrefix(pathname ?? "/")
@@ -194,13 +174,6 @@ export function Nav({ locale, t }: Props) {
           />
 
           {localeSwitcher}
-
-          <div
-            className="h-5 w-px bg-current/15 dark:bg-current/25 shrink-0"
-            aria-hidden="true"
-          />
-
-          {joinLink}
         </div>
 
         <button
@@ -269,13 +242,6 @@ export function Nav({ locale, t }: Props) {
                   {t.language}
                 </p>
                 {localeSwitcher}
-              </div>
-
-              <div className="border-t border-current/10 dark:border-current/20 pt-6">
-                <p className="mb-3 text-[10px] uppercase tracking-[0.2em] text-foreground/50">
-                  {t.youtube}
-                </p>
-                {joinLink}
               </div>
             </div>
           </div>

--- a/src/dictionaries/boundary.ts
+++ b/src/dictionaries/boundary.ts
@@ -19,7 +19,7 @@ export const boundaryStrings: Record<
   en: {
     errorTitle: "Something went wrong",
     errorBody:
-      "We couldn't load this page right now. This is usually temporary — try again in a moment.",
+      "We couldn't load this page right now. This is usually temporary, so try again in a moment.",
     tryAgain: "Try again",
     goHome: "Go home",
     notFoundTitle: "Whoops 👀",
@@ -31,7 +31,7 @@ export const boundaryStrings: Record<
   pt: {
     errorTitle: "Algo deu errado",
     errorBody:
-      "Não conseguimos carregar esta página agora. Normalmente é temporário — tente de novo em instantes.",
+      "Não conseguimos carregar esta página agora. Normalmente é temporário, tente de novo em instantes.",
     tryAgain: "Tentar de novo",
     goHome: "Voltar ao início",
     notFoundTitle: "Opa 👀",

--- a/src/dictionaries/en.json
+++ b/src/dictionaries/en.json
@@ -7,7 +7,7 @@
     },
     "videos": {
       "title": "Videos | Daniel Bergholz",
-      "description": "Watch Daniel Bergholz's videos or read the article version — fullstack web development tutorials, programming tips, and developer content"
+      "description": "Watch Daniel Bergholz's videos or read the article version: fullstack web development tutorials, programming tips, and developer content"
     },
     "courses": {
       "title": "Courses | Daniel Bergholz",
@@ -65,7 +65,7 @@
   },
   "videos": {
     "title": "Videos",
-    "intro": "Everything I publish, newest first. Most videos come with a written version too — watch on YouTube or read the article, whichever you prefer."
+    "intro": "Everything I publish, newest first. Most videos come with a written version too: watch on YouTube or read the article, whichever you prefer."
   },
   "feed": {
     "searchLabel": "Search videos and articles",
@@ -133,13 +133,13 @@
   },
   "workWithMe": {
     "title": "Work with me",
-    "intro": "I help companies and developers get more out of AI — through trainings, consulting, mentorship, and content that reaches thousands of developers.",
+    "intro": "I help companies and developers get more out of AI through trainings, consulting, mentorship, and content that reaches thousands of developers.",
     "comingSoon": "Coming soon",
     "open": "Open",
     "services": {
       "business": {
         "title": "Business Consulting",
-        "description": "I help your business grow with AI: hands-on technical trainings and workshops for your employees, and consulting to automate manual work in any role — engineering, support, operations, and beyond.",
+        "description": "I help your business grow with AI: hands-on technical trainings and workshops for your employees, and consulting to automate manual work in any role, from engineering to support and operations.",
         "highlights": [
           "Technical trainings and workshops for your team",
           "Automation of manual work in any role",
@@ -149,7 +149,7 @@
       },
       "mentorship": {
         "title": "1-on-1 Mentorship",
-        "description": "Individual mentorship for developers who want to level up. I help you adopt cutting-edge AI tooling — and help Brazilian devs land a remote job abroad.",
+        "description": "Individual mentorship for developers who want to level up. I help you adopt cutting-edge AI tooling and help Brazilian devs land a remote job abroad.",
         "highlights": [
           "Adopt cutting-edge AI tooling in your daily work",
           "Land a remote job abroad (for Brazilian devs)",
@@ -179,11 +179,11 @@
     "ai": {
       "engineering": {
         "title": "AI-assisted software engineering",
-        "description": "Ship in days what used to take weeks — without giving up quality."
+        "description": "Ship in days what used to take weeks, without giving up quality."
       },
       "automation": {
         "title": "Automation",
-        "description": "Turn repetitive manual work into reliable workflows, for any role — not just engineering."
+        "description": "Turn repetitive manual work into reliable workflows for any role, not just engineering."
       },
       "agents": {
         "title": "Cloud agents working 24/7",
@@ -191,7 +191,7 @@
       }
     },
     "stackHeading": "Tech stack",
-    "outro": "Interested in any of these? Send me an email and let's talk — I'll let you know as soon as consulting and mentorship open up.",
+    "outro": "Interested in any of these? Send me an email and let's talk. I'll let you know as soon as consulting and mentorship open up.",
     "emailTitle": "Send email to Daniel Bergholz"
   }
 }

--- a/src/dictionaries/en.json
+++ b/src/dictionaries/en.json
@@ -1,9 +1,9 @@
 {
   "meta": {
     "home": {
-      "title": "Daniel Bergholz - Software Engineer, Content Creator & Solopreneur",
-      "description": "Daniel Bergholz is a Software Engineer, Content Creator and Solopreneur from Brazil building SaaS products and teaching programming to developers",
-      "ogDescription": "Daniel Bergholz is a Software Engineer, Content Creator and Solopreneur from Brazil building SaaS products and teaching programming"
+      "title": "Daniel Bergholz - Content Creator, Educator & Consultant",
+      "description": "Daniel Bergholz is a Content Creator, Educator and Consultant from Brazil, teaching programming and helping companies and developers get more out of AI",
+      "ogDescription": "Daniel Bergholz is a Content Creator, Educator and Consultant from Brazil, teaching programming and helping companies get more out of AI"
     },
     "videos": {
       "title": "Videos | Daniel Bergholz",
@@ -23,7 +23,7 @@
     },
     "workWithMe": {
       "title": "Work With Me - Daniel Bergholz",
-      "description": "Hire Daniel Bergholz as a fullstack developer, contractor, or content collaborator. Specializing in Elixir, Phoenix, React, and AI-driven development for startups."
+      "description": "Business consulting, 1-on-1 mentorship, and content collaborations with Daniel Bergholz. Technical trainings, workshops, AI adoption, and automation."
     }
   },
   "nav": {
@@ -32,12 +32,9 @@
     "courses": "Courses",
     "products": "Products",
     "workWithMe": "Work with me",
-    "members": "YouTube Members",
-    "membersAria": "Join on YouTube (opens in a new tab)",
     "openMenu": "Open menu",
     "closeMenu": "Close menu",
     "pages": "Pages",
-    "youtube": "YouTube",
     "language": "Language"
   },
   "footer": {
@@ -52,7 +49,7 @@
     "hello": "Hello",
     "introBefore": "My name is",
     "name": "Daniel Bergholz",
-    "introAfter": ", I'm a Software Engineer, Content Creator and Solopreneur from Brazil",
+    "introAfter": ", I'm a Content Creator, Educator and Consultant from Brazil",
     "getInTouch": "Get in touch",
     "getInTouchAria": "Get in touch via email",
     "socialAria": "Social Media",
@@ -64,8 +61,7 @@
     "viewAll": "View all",
     "viewAllTitle": "See all videos and articles",
     "noVideosBefore": "No videos available right now. Check back soon or browse",
-    "noVideosLink": "all content",
-    "membershipAria": "Channel membership"
+    "noVideosLink": "all content"
   },
   "videos": {
     "title": "Videos",
@@ -108,7 +104,6 @@
   "links": {
     "title": "Links",
     "sectionAria": "Social Media Links",
-    "premium": "Premium",
     "blog": "Blog"
   },
   "products": {
@@ -138,28 +133,28 @@
   },
   "workWithMe": {
     "title": "Work with me",
-    "intro": "Fullstack developer specializing in AI-driven development. I ship fast, build products from scratch, and create content that reaches thousands of developers.",
-    "available": "Available",
+    "intro": "I help companies and developers get more out of AI — through trainings, consulting, mentorship, and content that reaches thousands of developers.",
+    "comingSoon": "Coming soon",
     "open": "Open",
     "services": {
-      "startup": {
-        "title": "Startup Engineering",
-        "description": "Looking for a fullstack developer who can ship fast and own features end-to-end? I thrive in mid-stage startups where speed and quality both matter. 6+ years building products from zero to production.",
+      "business": {
+        "title": "Business Consulting",
+        "description": "I help your business grow with AI: hands-on technical trainings and workshops for your employees, and consulting to automate manual work in any role — engineering, support, operations, and beyond.",
         "highlights": [
-          "Elixir, Phoenix, React, TypeScript, GraphQL",
-          "AI integrations (OpenAI, Groq, Claude)",
-          "0-to-1 product development and scaling",
-          "10x productivity with AI-driven workflows"
+          "Technical trainings and workshops for your team",
+          "Automation of manual work in any role",
+          "AI-assisted software engineering practices",
+          "Delivered in English or Portuguese"
         ]
       },
-      "contract": {
-        "title": "Contract Work",
-        "description": "Available for focused contract engagements. I deliver fast without cutting corners, leveraging Claude Code to maintain a high level of output. Best for MVPs, AI features, and fullstack web applications.",
+      "mentorship": {
+        "title": "1-on-1 Mentorship",
+        "description": "Individual mentorship for developers who want to level up. I help you adopt cutting-edge AI tooling — and help Brazilian devs land a remote job abroad.",
         "highlights": [
-          "MVPs and proof-of-concept builds",
-          "AI feature integration into existing products",
-          "B2B SaaS and admin dashboards",
-          "Phoenix/React fullstack applications"
+          "Adopt cutting-edge AI tooling in your daily work",
+          "Land a remote job abroad (for Brazilian devs)",
+          "CV, LinkedIn, and interview preparation",
+          "Guidance from years of working remotely for international companies"
         ]
       },
       "content": {
@@ -180,8 +175,23 @@
       "courseshelf": "Founded a community-driven course review platform, built with AI",
       "techschool": "Open source education platform with 2K monthly visitors"
     },
+    "aiHeading": "AI tooling",
+    "ai": {
+      "engineering": {
+        "title": "AI-assisted software engineering",
+        "description": "Ship in days what used to take weeks — without giving up quality."
+      },
+      "automation": {
+        "title": "Automation",
+        "description": "Turn repetitive manual work into reliable workflows, for any role — not just engineering."
+      },
+      "agents": {
+        "title": "Cloud agents working 24/7",
+        "description": "Agents that review code, fix bugs, and move work forward while your team sleeps."
+      }
+    },
     "stackHeading": "Tech stack",
-    "outro": "Interested in working together? Send me an email and let's talk.",
+    "outro": "Interested in any of these? Send me an email and let's talk — I'll let you know as soon as consulting and mentorship open up.",
     "emailTitle": "Send email to Daniel Bergholz"
   }
 }

--- a/src/dictionaries/pt.json
+++ b/src/dictionaries/pt.json
@@ -1,9 +1,9 @@
 {
   "meta": {
     "home": {
-      "title": "Daniel Bergholz - Engenheiro de Software, Criador de Conteúdo e Solopreneur",
-      "description": "Daniel Bergholz é engenheiro de software, criador de conteúdo e solopreneur. Constrói produtos SaaS e ensina programação para devs",
-      "ogDescription": "Daniel Bergholz é engenheiro de software, criador de conteúdo e solopreneur. Constrói produtos SaaS e ensina programação"
+      "title": "Daniel Bergholz - Criador de Conteúdo, Educador e Consultor",
+      "description": "Daniel Bergholz é criador de conteúdo, educador e consultor. Ensina programação e ajuda empresas e devs a aproveitarem melhor a IA",
+      "ogDescription": "Daniel Bergholz é criador de conteúdo, educador e consultor. Ensina programação e ajuda empresas a aproveitarem melhor a IA"
     },
     "videos": {
       "title": "Vídeos | Daniel Bergholz",
@@ -23,7 +23,7 @@
     },
     "workWithMe": {
       "title": "Trabalhe Comigo - Daniel Bergholz",
-      "description": "Contrate Daniel Bergholz como desenvolvedor fullstack, contractor ou colaborador de conteúdo. Especialista em Elixir, Phoenix, React e desenvolvimento com IA para startups."
+      "description": "Consultoria para empresas, mentoria individual e collabs de conteúdo com Daniel Bergholz. Treinamentos técnicos, workshops, adoção de IA e automação."
     }
   },
   "nav": {
@@ -32,12 +32,9 @@
     "courses": "Cursos",
     "products": "Produtos",
     "workWithMe": "Trabalhe comigo",
-    "members": "Membros do YouTube",
-    "membersAria": "Vire membro no YouTube (abre em nova aba)",
     "openMenu": "Abrir menu",
     "closeMenu": "Fechar menu",
     "pages": "Páginas",
-    "youtube": "YouTube",
     "language": "Idioma"
   },
   "footer": {
@@ -52,7 +49,7 @@
     "hello": "Olá",
     "introBefore": "Meu nome é",
     "name": "Daniel Bergholz",
-    "introAfter": ", sou engenheiro de software, criador de conteúdo e solopreneur",
+    "introAfter": ", sou criador de conteúdo, educador e consultor",
     "getInTouch": "Fale comigo",
     "getInTouchAria": "Fale comigo por email",
     "socialAria": "Redes sociais",
@@ -64,8 +61,7 @@
     "viewAll": "Ver todos",
     "viewAllTitle": "Ver todos os vídeos e artigos",
     "noVideosBefore": "Nenhum vídeo disponível no momento. Volte em breve ou veja",
-    "noVideosLink": "todo o conteúdo",
-    "membershipAria": "Membros do canal"
+    "noVideosLink": "todo o conteúdo"
   },
   "videos": {
     "title": "Vídeos",
@@ -108,7 +104,6 @@
   "links": {
     "title": "Links",
     "sectionAria": "Links das redes sociais",
-    "premium": "Premium",
     "blog": "Blog"
   },
   "products": {
@@ -138,28 +133,28 @@
   },
   "workWithMe": {
     "title": "Trabalhe comigo",
-    "intro": "Desenvolvedor fullstack especializado em desenvolvimento com IA. Entrego rápido, construo produtos do zero e crio conteúdo que alcança milhares de devs.",
-    "available": "Disponível",
+    "intro": "Ajudo empresas e devs a aproveitarem melhor a IA — com treinamentos, consultoria, mentoria e conteúdo que alcança milhares de devs.",
+    "comingSoon": "Em breve",
     "open": "Aberto",
     "services": {
-      "startup": {
-        "title": "Engenharia para startups",
-        "description": "Procurando um dev fullstack que entrega rápido e assume features de ponta a ponta? Eu me destaco em startups em estágio intermediário, onde velocidade e qualidade importam igualmente. Mais de 6 anos construindo produtos do zero até a produção.",
+      "business": {
+        "title": "Consultoria para empresas",
+        "description": "Ajudo sua empresa a crescer com IA: treinamentos técnicos e workshops práticos para seus funcionários, e consultoria para automatizar trabalho manual em qualquer área — engenharia, suporte, operações e mais.",
         "highlights": [
-          "Elixir, Phoenix, React, TypeScript, GraphQL",
-          "Integrações com IA (OpenAI, Groq, Claude)",
-          "Desenvolvimento de produto do 0 ao 1 e escala",
-          "Produtividade 10x com fluxos de trabalho guiados por IA"
+          "Treinamentos técnicos e workshops para o seu time",
+          "Automação de trabalho manual em qualquer área",
+          "Práticas de engenharia de software com IA",
+          "Em português ou inglês"
         ]
       },
-      "contract": {
-        "title": "Trabalho por contrato",
-        "description": "Disponível para contratos com escopo focado. Entrego rápido sem cortar caminho, usando Claude Code para manter um alto nível de produção. Ideal para MVPs, features de IA e aplicações web fullstack.",
+      "mentorship": {
+        "title": "Mentoria individual",
+        "description": "Mentoria individual para devs que querem evoluir. Te ajudo a adotar as ferramentas de IA mais avançadas — e a conquistar uma vaga remota pra trabalhar pra gringa.",
         "highlights": [
-          "MVPs e provas de conceito",
-          "Integração de features de IA em produtos existentes",
-          "SaaS B2B e painéis administrativos",
-          "Aplicações fullstack com Phoenix/React"
+          "Adote as ferramentas de IA mais avançadas no seu dia a dia",
+          "Conquiste uma vaga remota no exterior",
+          "Preparação de currículo, LinkedIn e entrevistas",
+          "Orientação de quem trabalha remoto pra gringa há anos"
         ]
       },
       "content": {
@@ -180,8 +175,23 @@
       "courseshelf": "Fundei uma plataforma comunitária de avaliação de cursos, construída com IA",
       "techschool": "Plataforma open source de educação com 2 mil visitantes mensais"
     },
+    "aiHeading": "Ferramentas de IA",
+    "ai": {
+      "engineering": {
+        "title": "Engenharia de software assistida por IA",
+        "description": "Entregue em dias o que antes levava semanas — sem abrir mão da qualidade."
+      },
+      "automation": {
+        "title": "Automação",
+        "description": "Transforme trabalho manual repetitivo em fluxos confiáveis, para qualquer área — não só engenharia."
+      },
+      "agents": {
+        "title": "Agentes na nuvem trabalhando 24/7",
+        "description": "Agentes que revisam código, corrigem bugs e fazem o trabalho andar enquanto seu time dorme."
+      }
+    },
     "stackHeading": "Stack",
-    "outro": "Quer trabalhar comigo? Me manda um email e vamos conversar.",
+    "outro": "Ficou interessado? Me manda um email e vamos conversar — te aviso assim que a consultoria e a mentoria abrirem.",
     "emailTitle": "Enviar email para Daniel Bergholz"
   }
 }

--- a/src/dictionaries/pt.json
+++ b/src/dictionaries/pt.json
@@ -1,13 +1,13 @@
 {
   "meta": {
     "home": {
-      "title": "Daniel Bergholz - Criador de Conteúdo, Educador e Consultor",
-      "description": "Daniel Bergholz é criador de conteúdo, educador e consultor. Ensina programação e ajuda empresas e devs a aproveitarem melhor a IA",
-      "ogDescription": "Daniel Bergholz é criador de conteúdo, educador e consultor. Ensina programação e ajuda empresas a aproveitarem melhor a IA"
+      "title": "Daniel Bergholz - Criador de Conteúdo, Professor e Consultor",
+      "description": "Daniel Bergholz é criador de conteúdo, professor e consultor. Ensina programação e ajuda empresas e devs a aproveitarem melhor a IA",
+      "ogDescription": "Daniel Bergholz é criador de conteúdo, professor e consultor. Ensina programação e ajuda empresas a aproveitarem melhor a IA"
     },
     "videos": {
       "title": "Vídeos | Daniel Bergholz",
-      "description": "Assista aos vídeos do Daniel Bergholz ou leia a versão em artigo — tutoriais de desenvolvimento web fullstack, dicas de programação e conteúdo para devs"
+      "description": "Assista aos vídeos do Daniel Bergholz ou leia a versão em artigo: tutoriais de desenvolvimento web fullstack, dicas de programação e conteúdo para devs"
     },
     "courses": {
       "title": "Cursos | Daniel Bergholz",
@@ -49,7 +49,7 @@
     "hello": "Olá",
     "introBefore": "Meu nome é",
     "name": "Daniel Bergholz",
-    "introAfter": ", sou criador de conteúdo, educador e consultor",
+    "introAfter": ", sou criador de conteúdo, professor e consultor",
     "getInTouch": "Fale comigo",
     "getInTouchAria": "Fale comigo por email",
     "socialAria": "Redes sociais",
@@ -65,7 +65,7 @@
   },
   "videos": {
     "title": "Vídeos",
-    "intro": "Tudo que eu publico, do mais recente ao mais antigo. A maioria dos vídeos também tem versão escrita — assista no YouTube ou leia o artigo, como preferir."
+    "intro": "Tudo que eu publico, do mais recente ao mais antigo. A maioria dos vídeos também tem versão escrita: assista no YouTube ou leia o artigo, como preferir."
   },
   "feed": {
     "searchLabel": "Buscar vídeos e artigos",
@@ -133,13 +133,13 @@
   },
   "workWithMe": {
     "title": "Trabalhe comigo",
-    "intro": "Ajudo empresas e devs a aproveitarem melhor a IA — com treinamentos, consultoria, mentoria e conteúdo que alcança milhares de devs.",
+    "intro": "Ajudo empresas e devs a aproveitarem melhor a IA com treinamentos, consultoria, mentoria e conteúdo que alcança milhares de devs.",
     "comingSoon": "Em breve",
     "open": "Aberto",
     "services": {
       "business": {
         "title": "Consultoria para empresas",
-        "description": "Ajudo sua empresa a crescer com IA: treinamentos técnicos e workshops práticos para seus funcionários, e consultoria para automatizar trabalho manual em qualquer área — engenharia, suporte, operações e mais.",
+        "description": "Ajudo sua empresa a crescer com IA: treinamentos técnicos e workshops práticos para seus funcionários, e consultoria para automatizar trabalho manual em qualquer área, de engenharia a suporte e operações.",
         "highlights": [
           "Treinamentos técnicos e workshops para o seu time",
           "Automação de trabalho manual em qualquer área",
@@ -149,7 +149,7 @@
       },
       "mentorship": {
         "title": "Mentoria individual",
-        "description": "Mentoria individual para devs que querem evoluir. Te ajudo a adotar as ferramentas de IA mais avançadas — e a conquistar uma vaga remota pra trabalhar pra gringa.",
+        "description": "Mentoria individual para devs que querem evoluir. Te ajudo a adotar as ferramentas de IA mais avançadas e a conquistar uma vaga remota pra trabalhar pra gringa.",
         "highlights": [
           "Adote as ferramentas de IA mais avançadas no seu dia a dia",
           "Conquiste uma vaga remota no exterior",
@@ -179,11 +179,11 @@
     "ai": {
       "engineering": {
         "title": "Engenharia de software assistida por IA",
-        "description": "Entregue em dias o que antes levava semanas — sem abrir mão da qualidade."
+        "description": "Entregue em dias o que antes levava semanas, sem abrir mão da qualidade."
       },
       "automation": {
         "title": "Automação",
-        "description": "Transforme trabalho manual repetitivo em fluxos confiáveis, para qualquer área — não só engenharia."
+        "description": "Transforme trabalho manual repetitivo em fluxos confiáveis para qualquer área, não só engenharia."
       },
       "agents": {
         "title": "Agentes na nuvem trabalhando 24/7",
@@ -191,7 +191,7 @@
       }
     },
     "stackHeading": "Stack",
-    "outro": "Ficou interessado? Me manda um email e vamos conversar — te aviso assim que a consultoria e a mentoria abrirem.",
+    "outro": "Ficou interessado? Me manda um email e vamos conversar. Te aviso assim que a consultoria e a mentoria abrirem.",
     "emailTitle": "Enviar email para Daniel Bergholz"
   }
 }


### PR DESCRIPTION
## What changed

Refocuses the site from "developer open to work" to content creator, educator, and consultant.

**Work with me page**
- Removed the Startup Engineering and Contract Work services
- Added **Business Consulting** (consultoria para empresas) and **1-on-1 Mentorship** (mentoria individual), both with an amber "Coming soon" badge; Content & Collabs stays at the bottom, still "Open"
- Consulting copy: technical trainings and workshops for employees, automation of manual work in any role
- Mentorship copy: adopt cutting-edge AI tooling, help Brazilian devs land remote jobs abroad ("trabalhar pra gringa")
- The "Tech stack" section is now **AI tooling**, focused on business outcomes (AI-assisted engineering, automation, cloud agents 24/7), with the stack chips kept below under a de-emphasized label
- The outro invites emails as a waitlist for when consulting/mentorship open
- Updated metadata keywords to match

**Membership / early access**
- The membership CTA now appears only at the bottom of `/videos` and `/courses` (newly added on courses)
- Removed: the "YouTube Members" nav button (desktop + mobile), the home-page membership card, and the Premium diamond link on `/links`

**Positioning**
- Home intro and meta titles/descriptions now read "Content Creator, Educator and Consultant" in both locales

## Why

Daniel is refocusing his career from employee/solopreneur to content creator, teacher, mentor, and consultant. The site should sell services and outcomes, not employment or the membership.

## Notes for review

- Both dictionaries updated in lockstep; the shape-parity unit test passes
- `npm run format`, `npm run check`, `npm test` (25 passing), and `npm run build` all pass
- Verified in the browser in both pt and en; no console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Marketing copy and static page layout only; no auth, data, or API behavior changes.
> 
> **Overview**
> Refocuses the personal site from **open-to-work developer** to **content creator, educator, and consultant**, with copy and layout changes across EN/PT.
> 
> On **Work with me**, **Startup Engineering** and **Contract Work** are replaced by **Business Consulting** and **1-on-1 Mentorship** (amber **Coming soon** badges). **Content & Collabs** stays **Open**. A new **AI tooling** section highlights outcomes (engineering, automation, cloud agents); tech stack chips sit below a smaller label, with added tools (SQLite, Cursor, opencode, OpenAI). Metadata keywords and the email outro now frame consulting/mentorship as opening soon.
> 
> **Membership** is narrowed: `MembershipCTA` is removed from the home page, the nav (desktop and mobile YouTube Members link), and the Premium diamond on `/links`; it is **added** at the bottom of `/courses` (alongside existing `/videos` placement).
> 
> Home intro and meta titles/descriptions now say **Content Creator, Educator & Consultant** instead of software engineer/solopreneur. Minor punctuation tweaks in error-boundary strings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f3207aa78614cde296f5f0309ece672824cd812. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->